### PR TITLE
Examples: Add a custom post type to Playground

### DIFF
--- a/blueprints/custom-post/blueprints.json
+++ b/blueprints/custom-post/blueprints.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "meta": {
+        "title": "Custom Post Type: Books",
+        "description": "Blueprint that added a custom post type to playground",
+        "author": "bph",
+        "categories": ["Content", "CPT"]
+    },
+    "landingPage": "/wp-admin/",
+    "steps":[
+            {
+                "step": "login"
+            },
+            {
+                "step": "mkdir",
+                "path": "/wordpress/wp-content/plugins/books"
+            },
+            {
+                "step": "writeFile",
+                "path": "/wordpress/wp-content/plugins/books/books.php",
+                "data": {
+                    "resource": "url",
+                    "url": "https://raw.githubusercontent.com/adamziel/blueprints/custom-post/book.txt"
+                }
+            },
+            {
+                "step": "activatePlugin",
+                "pluginPath": "/wordpress/wp-content/plugins/books/"
+            }
+            ]
+}

--- a/blueprints/custom-post/books.txt
+++ b/blueprints/custom-post/books.txt
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Plugin Name:       Books
+ * Plugin URI:        https://icodeforapurpose.com
+ * Description:       Create the Book Custom post Type
+ * Version:           0.1.
+ * Requires at least: 6.0
+ * Requires PHP:      7.2
+ * Author:            Birgit Pauli-Haack
+ * Author URI:        https://profiles.wordpress.org/bph
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Update URI:        https://example.com/my-plugin/
+ * Text Domain:       gbt
+ * Domain Path:       /languages
+ */
+
+
+// Register Custom Post Type
+function register_books() {
+
+	$labels = array(
+		'name'                  => _x( 'Books', 'Post Type General Name', 'gbt' ),
+		'singular_name'         => _x( 'Book', 'Post Type Singular Name', 'gbt' ),
+		'menu_name'             => __( 'Books', 'gbt' ),
+		'name_admin_bar'        => __( 'Books', 'gbt' ),
+		'archives'              => __( 'Book Archives', 'gbt' ),
+		'attributes'            => __( 'Book Attributes', 'gbt' ),
+		'parent_item_colon'     => __( 'Parent book', 'gbt' ),
+		'all_items'             => __( 'All Books', 'gbt' ),
+		'add_new_item'          => __( 'Add New Book', 'gbt' ),
+		'add_new'               => __( 'Add New Book', 'gbt' ),
+		'new_item'              => __( 'New Book', 'gbt' ),
+		'edit_item'             => __( 'Edit Book', 'gbt' ),
+		'update_item'           => __( 'Update Book', 'gbt' ),
+		'view_item'             => __( 'View Book', 'gbt' ),
+		'view_items'            => __( 'View Books', 'gbt' ),
+		'search_items'          => __( 'Search Books', 'gbt' ),
+		'not_found'             => __( 'Not found', 'gbt' ),
+		'not_found_in_trash'    => __( 'Not found in Trash', 'gbt' ),
+		'featured_image'        => __( 'Featured Image', 'gbt' ),
+		'set_featured_image'    => __( 'Set featured image', 'gbt' ),
+		'remove_featured_image' => __( 'Remove featured image', 'gbt' ),
+		'use_featured_image'    => __( 'Use as featured image', 'gbt' ),
+		'insert_into_item'      => __( 'Insert into item', 'gbt' ),
+		'uploaded_to_this_item' => __( 'Uploaded to this item', 'gbt' ),
+		'items_list'            => __( 'Items list', 'gbt' ),
+		'items_list_navigation' => __( 'Items list navigation', 'gbt' ),
+		'filter_items_list'     => __( 'Filter items list', 'gbt' ),
+	);
+	$args = array(
+		'label'                 => __( 'Book', 'gbt' ),
+		'description'           => __( 'Books', 'gbt' ),
+		'labels'                => $labels,
+		'supports'              => array( 'title', 'editor', excerpt, featured_image),
+		'taxonomies'            => array( 'genre', ' publisher' ),
+		'hierarchical'          => false,
+		'public'                => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'menu_position'         => 5,
+		'menu_icon'             => 'dashicons-book-alt',
+		'show_in_admin_bar'     => true,
+		'show_in_nav_menus'     => true,
+		'can_export'            => true,
+		'has_archive'           => true,
+		'exclude_from_search'   => false,
+		'publicly_queryable'    => true,
+		'capability_type'       => 'post',
+		'show_in_rest'          => true,
+	);
+	register_post_type( 'gbtbooks', $args );
+
+}
+add_action( 'init', 'register_books', 0 );

--- a/blueprints/grid-variations/blueprint.json
+++ b/blueprints/grid-variations/blueprint.json
@@ -9,9 +9,7 @@
     "landingPage": "/wp-admin/site-editor.php",
     "steps":[
         {
-            "step": "login",
-            "username": "admin",
-            "password": "password"
+            "step": "login"
         },
         {
             "step":"installPlugin",

--- a/blueprints/posts-via-wp-cli/blueprint.json
+++ b/blueprints/posts-via-wp-cli/blueprint.json
@@ -6,7 +6,7 @@
         "author": "bph",
         "categories": ["Content", "wpcli"]
     },
-    "landingPage": "wp-admin/edit.php",
+    "landingPage": "/wp-admin/edit.php",
     "steps":[
                 {
                     "step": "login",

--- a/blueprints/posts-via-wp-cli/blueprint.json
+++ b/blueprints/posts-via-wp-cli/blueprint.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "meta": {
+        "title": "Use wp-cli command to add posts",
+        "description": "Blueprint example to add posts via a wp-cli command.",
+        "author": "bph",
+        "categories": ["Content", "wpcli"]
+    },
+    "landingPage": "wp-admin/edit.php",
+    "steps":[
+                {
+                    "step": "login",
+                    "username": "admin",
+                    "password": "password"
+                },
+                {
+                    "step": "wp-cli",
+                    "command": "wp post generate --count=12 --post_type=post --post_date=1999-01-04"
+                }
+            ]
+}

--- a/blueprints/posts-via-wp-cli/blueprint.json
+++ b/blueprints/posts-via-wp-cli/blueprint.json
@@ -9,9 +9,7 @@
     "landingPage": "/wp-admin/edit.php",
     "steps":[
                 {
-                    "step": "login",
-                    "username": "admin",
-                    "password": "password"
+                    "step": "login"
                 },
                 {
                     "step": "wp-cli",

--- a/blueprints/theme-test/blueprint.json
+++ b/blueprints/theme-test/blueprint.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "meta": {
+        "title": "Theme Tester",
+        "description": "Blueprint example to add content and plugins to explore a theme",
+        "author": "bph",
+        "categories": ["themes", "content"]
+    },
+    "preferredVersions":{
+        "php":"8.0",
+        "wp":"beta"
+    },
+    "features":{
+        "networking":true
+    },
+    "steps":[
+        {
+            "step":"login",
+            "username":"admin",
+            "password":"password"
+        },
+        {
+            "step":"importFile",
+            "file":{
+                "resource":"url",
+                "url": "https://raw.githubusercontent.com/wpaccessibility/a11y-theme-unit-test/master/a11y-theme-unit-test-data.xml"
+                }
+        },
+        {
+            "step":"importFile",
+            "file":{
+                "resource":"url",
+                "url":"https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml"
+                }
+        },  
+        {
+            "step":"installPlugin",
+            "pluginZipFile":{
+            "resource":"wordpress.org/plugins",
+            "slug":"create-block-theme"
+            },
+            "progress":{
+                "weight":2
+            }
+        },
+        {
+
+            "step": "installTheme",
+            "themeZipFile": {
+                "resource": "wordpress.org/themes",
+                "slug": "twentytwentyfour"
+            },
+            "options": {
+                "activate": true
+            }
+    }
+    ]
+}

--- a/blueprints/theme-test/blueprint.json
+++ b/blueprints/theme-test/blueprint.json
@@ -15,9 +15,7 @@
     },
     "steps":[
         {
-            "step":"login",
-            "username":"admin",
-            "password":"password"
+            "step": "login"
         },
         {
             "step":"importFile",


### PR DESCRIPTION
Blueprint 
- create folder
- Add a file to create a plugin that adds a custom post type.   
- activate plugin 

Enable the user of playground to create posts with certain custom post type, and create single post and archive templates for this post type. 

It's v1 

small updates on other blueprints. 
