### PR TITLE
Add an "Install plugin from a gist" example

### DIFF
--- a/blueprints/install-plugin-from-gist/blueprint.json
+++ b/blueprints/install-plugin-from-gist/blueprint.json
@@ -1,0 +1,31 @@
+{
+	"meta": {
+		"title": "Install plugin from a gist",
+		"author": "zieladam",
+		"description": "Install and activate a WordPress plugin from a .php file stored in a gist.",
+		"categories": ["plugins"]
+	},
+	"landingPage": "/wp-admin/plugins.php",
+	"preferredVersions": {
+		"wp": "beta",
+		"php": "8.0"
+	},
+	"steps": [
+		{
+			"step": "login"
+		},
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/plugins/0-plugin.php",
+			"data": {
+				"resource": "url",
+				"url": "https://gist.githubusercontent.com/ndiego/456b74b243d86c97cda89264c68cbdee/raw/ff00cf25e6eebe4f5a4eaecff10286f71e65340b/block-hooks-demo.php"
+			}
+		},
+		{
+			"step": "activatePlugin",
+			"pluginName": "Block Hooks Demo",
+			"pluginPath": "0-plugin.php"
+		}
+	]
+}


### PR DESCRIPTION
Adds a Blueprint that installs a plugin from a PHP file stored in a GitHub gist. Referencing external URLs is technically against the contributing guidelines, but it is a useful example to provide so let's make an exception for this initial Blueprint.