### PR TITLE
Fix Contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,7 @@ Not sure how? Check out the [Blueprints 101](./docs/index.md).
 
 To keep the submission process smooth, please follow these guidelines:
 
-<<<<<<< HEAD
 Submit [a Pull Request (PR)](https://github.com/adamziel/blueprints/pulls) with your Blueprint. Consult this page [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) if you need a refresher on the process. 
-=======
-Submit [a Pull Request (PR)](https://github.com/wordpress/blueprints/pulls) with your Blueprint.
->>>>>>> 5b14b88 (Replace "adamziel/blueprints" with "wordpress/blueprints" in the documentation)
 
 The PR should contain:
 


### PR DESCRIPTION
Seems the transfer to the new repo left some residue that borked the formatting of the page. 
![Screenshot 2024-04-25 at 13 16 53](https://github.com/WordPress/blueprints/assets/39980/7d7d9a60-fd6f-405c-9443-a4b20500755f)

This update should fix it. 