### PR TITLE
"Login as editor" as an example for testing user roles

### DIFF
--- a/blueprints/login-as-editor/blueprint.json
+++ b/blueprints/login-as-editor/blueprint.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Login as an editor",
+		"description": "Test WordPress functionality as an editor rather than an administrator.",
+		"author": "bacoords",
+		"categories": ["User", "Role"]
+	},
+	"landingPage": "/wp-admin/",
+	"steps": [
+	  {
+		"step": "runPHP",
+		"code": "<?php require '/wordpress/wp-load.php'; $user_id = wp_create_user('myuser', 'mypass', 'myuser@localhost'); (new WP_User($user_id))->set_role('editor');"
+	  },
+	  {
+		"step": "login",
+		"username": "myuser",
+		"password": "mypass"
+	  }
+	]
+  }


### PR DESCRIPTION
This was a blueprint that @adamziel helped me with a while back and I think it'd be useful for others. I use it when quickly testing the Gutenberg feature differences between editor / administrator.

It was unclear in the instructions whether I should run the reindexing in my PR or not.

Related https://github.com/WordPress/wordpress-playground/issues/1129