### PR TITLE
Add a new blueprint for setting user meta.

### DIFF
--- a/blueprints/set-admin-color-scheme/blueprint.json
+++ b/blueprints/set-admin-color-scheme/blueprint.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Set the admin color scheme",
+		"description": "Set the admin color scheme to Modern using the updateUserMeta step.",
+		"author": "ndiego",
+		"categories": ["user meta"]
+	},
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"landingPage": "/wp-admin/?welcome=0",
+	"login": true,
+	"steps": [
+		{
+			"step": "updateUserMeta",
+			"meta": {
+				"admin_color": "modern"
+			},
+			"userId": 1
+		}
+	]
+}


### PR DESCRIPTION
This simple blueprint sets the WordPress admin color scheme to Modern using a [`updateUserMeta`](https://wordpress.github.io/wordpress-playground/blueprints-api/steps#UpdateUserMetaStep) step.