### PR TITLE
Editorial enhancements for Troubleshooting docs

### DIFF
--- a/docs/troubleshoot-debug-blueprints.md
+++ b/docs/troubleshoot-debug-blueprints.md
@@ -2,10 +2,10 @@
 
 When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
 
-## Review Common gotchas
+## Review common gotchas
 
-- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
-- Enable `networking`: to access wp.org assets (themes, plugins, blocks, or patterns), or load a stylesheet using [add_editor_style()](https://developer.wordpress.org/reference/functions/add_editor_style/) (say, when [creating a custom block style](https://developer.wordpress.org/news/2023/02/creating-custom-block-styles-in-wordpress-themes)), you’d need to enable the `networking` option: `"features": {"networking": true}`.
+- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you would need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+- Enable `networking`: to access wp.org assets (themes, plugins, blocks, or patterns), or load a stylesheet using [add_editor_style()](https://developer.wordpress.org/reference/functions/add_editor_style/) (say, when [creating a custom block style](https://developer.wordpress.org/news/2023/02/creating-custom-block-styles-in-wordpress-themes)), you would need to enable the `networking` option: `"features": {"networking": true}`.
 
 ## Blueprints Builder
 
@@ -14,7 +14,7 @@ You can use an in-browser [Blueprints editor](https://playground.wordpress.net/b
 > [!CAUTION]
 > The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
 
-## Check for erros in the browser console
+## Check for errors in the browser console
 
 If your Blueprint isn’t running as expected, open the browser developer tools to see if there are any errors. 
 


### PR DESCRIPTION
Addressing some typos and capitalization in Troubleshoot and debug Blueprints doc