### PR TITLE
Rewriting media upload requests

### DIFF
--- a/blueprints/redirect-upload-requests/blueprint.json
+++ b/blueprints/redirect-upload-requests/blueprint.json
@@ -1,13 +1,13 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
-		"title": "Pretty permalinks",
-		"description": "Set the permalink structure to use pretty permalinks.",
-		"author": "bgrgicak",
+		"title": "Redirect upload requests",
+		"description": "Redirect any requests to files within the uploads directory to an external host. This is useful when you have a lot of image attachments in your playground but don’t want to include them all in the blueprint.",
+		"author": "ivanblagdan",
 		"categories": ["Settings"]
 	},
 	"landingPage": "/category/uncategorized/",
-	"constsnats": {
+	"constants": {
 		"PLAYGROUND_REDIRECT_UPLOADS_URL": "https://production.example.com"
 	},
 	"steps": [

--- a/blueprints/redirect-upload-requests/blueprint.json
+++ b/blueprints/redirect-upload-requests/blueprint.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
-		"title": "Redirect upload requests",
+		"title": "Serve media files from another host",
 		"description": "Redirect any requests to files within the uploads directory to an external host. This is useful when you have a lot of image attachments in your playground but don’t want to include them all in the blueprint.",
 		"author": "ivanblagdan",
 		"categories": ["Settings"]

--- a/blueprints/redirect-upload-requests/blueprint.json
+++ b/blueprints/redirect-upload-requests/blueprint.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Pretty permalinks",
+		"description": "Set the permalink structure to use pretty permalinks.",
+		"author": "bgrgicak",
+		"categories": ["Settings"]
+	},
+	"landingPage": "/category/uncategorized/",
+	"constsnats": {
+		"PLAYGROUND_REDIRECT_UPLOADS_URL": "https://production.example.com"
+	},
+	"steps": [
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/mu-plugins/redirect-uploads.php",
+			"data": "<?php add_action('init', function() { if (!defined('PLAYGROUND_REDIRECT_UPLOADS_URL')) exit; $request_uri = $_SERVER['REQUEST_URI']; $uploads_position = strpos($request_uri, '/wp-content/uploads'); if ($uploads_position !== false) { $uploads_path = substr($request_uri, $uploads_position); $redirect_url = PLAYGROUND_REDIRECT_UPLOADS_URL . $uploads_path; wp_redirect($redirect_url, 302); exit; } });"
+		}
+	]
+}


### PR DESCRIPTION
I had a situation where I wanted playgrounds to mirror a heavy production website with media upload attachments.  We have a similar pattern in-house for local dev environments where we reverse proxying image requests to the prod domain.
The following is a basic example of how I've dealt with the problem by intercepting and redirecting requests for `/wp-content/uploads*` requests.