### PR TITLE
Update the pretty permalinks Blueprint to Enable User Login

### DIFF
--- a/blueprints/use-pretty-permalinks/blueprint.json
+++ b/blueprints/use-pretty-permalinks/blueprint.json
@@ -7,6 +7,7 @@
 		"categories": ["Settings"]
 	},
 	"landingPage": "/category/uncategorized/",
+	"login": true,
 	"steps": [
 		{
 			"step": "writeFile",


### PR DESCRIPTION
I updated this blueprint to enable user login functionality. This change allows users to log in while preserving the existing permalink settings.

![Huzaifa-20240901144955](https://github.com/user-attachments/assets/1b9e71e8-1e59-46c8-9a08-9ac878537135)
