### PR TITLE
Replace Create Block Theme plugin step with shortcut

### DIFF
--- a/blueprints/theme-a11y-test/blueprint.json
+++ b/blueprints/theme-a11y-test/blueprint.json
@@ -13,6 +13,9 @@
 	"features": {
 		"networking": true
 	},
+	"plugins": [
+		"create-block-theme"
+	]
 	"steps": [
 		{
 			"step": "login"
@@ -29,16 +32,6 @@
 			"file": {
 				"resource": "url",
 				"url": "https://raw.githubusercontent.com/WordPress/theme-test-data/master/themeunittestdata.wordpress.xml"
-			}
-		},
-		{
-			"step": "installPlugin",
-			"pluginZipFile": {
-				"resource": "wordpress.org/plugins",
-				"slug": "create-block-theme"
-			},
-			"progress": {
-				"weight": 2
 			}
 		},
 		{

--- a/blueprints/theme-a11y-test/blueprint.json
+++ b/blueprints/theme-a11y-test/blueprint.json
@@ -15,7 +15,7 @@
 	},
 	"plugins": [
 		"create-block-theme"
-	]
+	],
 	"steps": [
 		{
 			"step": "login"


### PR DESCRIPTION
Fix: https://github.com/WordPress/blueprints/issues/49

Replace Create Block Theme plugin step with shortcut.