### PR TITLE
Blueprint to enable all three DataViews Gutenberg experiments

### DIFF
--- a/blueprints/gb-more-experiments/blueprint.json
+++ b/blueprints/gb-more-experiments/blueprint.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
-		"title": "Enable all Dataview Experiments in Gutenberg",
+		"title": "Enable all three Dataview Experiments in Gutenberg",
 		"author": "bph",
 		"description": "Blueprint example to enable multiple Experiments within the Gutenberg plugin ",
 		"categories": ["Gutenberg", "Experiments"]

--- a/blueprints/gb-more-experiments/blueprint.json
+++ b/blueprints/gb-more-experiments/blueprint.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Enable all Dataview Experiments in Gutenberg",
+		"author": "bph",
+		"description": "Blueprint example to enable multiple Experiments within the Gutenberg plugin ",
+		"categories": ["Gutenberg", "Experiments"]
+	},
+	"landingPage": "/wp-admin/site-editor.php",
+    "plugins": [ "gutenberg" ],
+	"steps": [
+		{
+			"step": "login"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-custom-dataviews' => true, 'gutenberg-new-posts-dashboard' => true, 'gutenberg-quick-edit-dataviews' => true )  );"
+		}
+	]
+}

--- a/blueprints/gb-more-experiments/blueprint.json
+++ b/blueprints/gb-more-experiments/blueprint.json
@@ -15,6 +15,13 @@
 		{
 			"step": "runPHP",
 			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-custom-dataviews' => true, 'gutenberg-new-posts-dashboard' => true, 'gutenberg-quick-edit-dataviews' => true )  );"
+		},
+		{
+			"step": "updateUserMeta",
+			"meta": {
+				"admin_color": "modern"
+			},
+			"userId": 1
 		}
 	]
 }


### PR DESCRIPTION
These three experiments are enabled in one step. 

- Data Views: add Custom Views
- Data Views: enable for Posts
- Data Views: add Quick Edit

