### PR TITLE
Update woo-shipping

### DIFF
--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -16,23 +16,22 @@
 			}
 		},
 		{
-			"step": "writeFiles",
-			"writeToPath": "/wordpress/wp-content/plugins/woo-shipping-method",
-			"filesTree": {
-			  "resource": "literal:directory",
-			  "name": "woo-shipping-method",
-			  "files": {
-				"woo-shipping-method.php": {
-				  "resource": "url",
-				   "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
-				}
-			  }
+			"step": "mkdir",
+			"path": "/wordpress/wp-content/plugins/woo-shipping-method"
+		},
+		{
+			"step": "writeFile",
+			"path": "/wordpress/wp-content/plugins/woo-shipping-method/woo-shipping-method.php",
+			"data": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
 			}
-		  },
-		  {
+		},
+		{
 			"step": "activatePlugin",
+			"pluginName": "woo-shipping-method",
 			"pluginPath": "woo-shipping-method/woo-shipping-method.php"
-		  }
+		}
 	],
 	"siteOptions": {
 		"blogName": "Woo Shipping Method"

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -7,6 +7,7 @@
 		"categories": ["woocommerce", "shipping", "flat_rate"]
 	},
 	"plugins":["woocommerce"],
+	"landingPage": "/wp-admin/edit.php?post_type=product",
 	"steps": [
 		{
 			"step": "importWxr",
@@ -31,6 +32,10 @@
 			"step": "activatePlugin",
 			"pluginName": "woo-shipping-method",
 			"pluginPath": "woo-shipping-method/woo-shipping-method.php"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php include 'wordpress/wp-load.php'; delete_transient( '_wc_activation_redirect' ); wp_insert_post(array( 'import_id' => 5, 'post_title' => 'Sample Product', 'post_content' => '<!-- wp:paragraph --><p>Sample product description</p><!-- /wp:paragraph -->','post_status' => 'publish','post_type' => 'product','post_author' => 1, 'meta_input' => array('_sku' => 'WEBTOFFEE-FEED-ITEM', '_regular_price' => 25.00, '_sale_price' => 22.00, '_price' => 22.00, '_wt_feed_brand' => 'WebToffee', '_wt_feed_gtin' => 'WEBTOFFEE123', '_wt_feed_mpn' => 'WebToffee123', '_wt_feed_color' => 'Red', '_wt_feed_gender' => 'Male' ) ) );"
 		}
 	],
 	"siteOptions": {

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -7,7 +7,7 @@
 		"categories": ["woocommerce", "shipping", "flat_rate"]
 	},
 	"plugins":["woocommerce"],
-	"landingPage": "/wp-admin/edit.php?post_type=product",
+	"landingPage": "/wp-admin/admin.php?page=wc-settings&tab=shipping",
 	"steps": [
 		{
 			"step": "importWxr",

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -16,8 +16,9 @@
 			}
 		},
 		{
-			"step": "installPlugin",
-			"pluginData": {
+			"step": "writeFiles",
+			"writeToPath": "/wordpress/wp-content/plugins/woo-shipping-method",
+			"filesTree": {
 			  "resource": "literal:directory",
 			  "name": "woo-shipping-method",
 			  "files": {
@@ -26,10 +27,11 @@
 				  "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
 				}
 			  }
-			},
-			"options": {
-			  "activate": true
 			}
+		  },
+		  {
+			"step": "activatePlugin",
+			"pluginPath": "woo-shipping-method/woo-shipping-method.php"
 		  }
 	],
 	"siteOptions": {

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -12,7 +12,7 @@
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-shipping/blueprints/woo-shipping/sample_products.xml"
+				"url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml"
 			}
 		},
 		{
@@ -23,7 +23,7 @@
 			  "files": {
 				"woo-shipping-method.php": {
 				  "resource": "url",
-				  "url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-shipping/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
+				  "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
 				}
 			  }
 			},

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -6,43 +6,33 @@
 		"author": "calvinrodrigues500",
 		"categories": ["woocommerce", "shipping", "flat_rate"]
 	},
+	"plugins":["woocommerce"],
 	"steps": [
-		{
-			"step": "setSiteOptions",
-			"options": {
-				"blogName": "Woo Shipping Method"
-			}
-		},
-		{
-			"step": "installPlugin",
-			"pluginZipFile": {
-				"resource": "wordpress.org/plugins",
-				"slug": "woocommerce"
-			}
-		},
 		{
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/calvinrodrigues500/blueprints/woo-shipping/blueprints/woo-shipping/sample_products.xml"
+				"url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-shipping/blueprints/woo-shipping/sample_products.xml"
 			}
 		},
 		{
-			"step": "mkdir",
-			"path": "/wordpress/wp-content/plugins/woo-shipping-method"
-		},
-		{
-			"step": "writeFile",
-			"path": "/wordpress/wp-content/plugins/woo-shipping-method/woo-shipping-method.php",
-			"data": {
-				"resource": "url",
-				"url": "https://raw.githubusercontent.com/calvinrodrigues500/blueprints/woo-shipping/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
+			"step": "installPlugin",
+			"pluginData": {
+			  "resource": "literal:directory",
+			  "name": "woo-shipping-method",
+			  "files": {
+				"woo-shipping-method.php": {
+				  "resource": "url",
+				  "url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-shipping/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
+				}
+			  }
+			},
+			"options": {
+			  "activate": true
 			}
-		},
-		{
-			"step": "activatePlugin",
-			"pluginName": "woo-shipping-method",
-			"pluginPath": "woo-shipping-method/woo-shipping-method.php"
-		}
-	]
+		  }
+	],
+	"siteOptions": {
+		"blogName": "Woo Shipping Method"
+	}
 }

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -24,7 +24,7 @@
 			  "files": {
 				"woo-shipping-method.php": {
 				  "resource": "url",
-				  "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
+				   "url": "https://raw.githubusercontent.com/calvinrodrigues500/blueprints/woo-shipping/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
 				}
 			  }
 			}

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -24,7 +24,7 @@
 			  "files": {
 				"woo-shipping-method.php": {
 				  "resource": "url",
-				   "url": "https://raw.githubusercontent.com/calvinrodrigues500/blueprints/woo-shipping/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
+				   "url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/woo-shipping-method/woo-shipping-method.php"
 				}
 			  }
 			}


### PR DESCRIPTION
Fixes #102 
- use shorthand for .org plugin
- use new `installPlugin` api
- replace reference to personal GitHub repo 
- moved `siteOptions` to  the end and use shorthand