### PR TITLE
update: two blueprint w/ gb experiements

### DIFF
--- a/blueprints/gb-more-experiments/blueprint.json
+++ b/blueprints/gb-more-experiments/blueprint.json
@@ -8,10 +8,8 @@
 	},
 	"landingPage": "/wp-admin/site-editor.php",
 	"plugins": ["gutenberg"],
+	"login":true,
 	"steps": [
-		{
-			"step": "login"
-		},
 		{
 			"step": "runPHP",
 			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-custom-dataviews' => true, 'gutenberg-new-posts-dashboard' => true, 'gutenberg-quick-edit-dataviews' => true )  );"

--- a/blueprints/grid-variations/blueprint.json
+++ b/blueprints/grid-variations/blueprint.json
@@ -7,22 +7,9 @@
 		"categories": ["Gutenberg", "Experiments"]
 	},
 	"landingPage": "/wp-admin/site-editor.php",
+	"login":true,
+	"plugins":["gutenberg"],
 	"steps": [
-		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
-		{
-			"step": "installPlugin",
-			"pluginZipFile": {
-				"resource": "wordpress.org/plugins",
-				"slug": "gutenberg"
-			},
-			"options": {
-				"activate": true
-			}
-		},
 		{
 			"step": "runPHP",
 			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-grid-interactivity' => true ) );"


### PR DESCRIPTION
Fixes #94 

Blueprints: 
- `grid-variations`
- `gb-more-experiments`

Both now use login and plugins shorthands. 


_Test using Playground only works for `gb-more-experiments`_