### PR TITLE
Update blueprint: "Reset data and import content (with logs)"

### DIFF
--- a/blueprints/reset-data-and-import-content/blueprint.json
+++ b/blueprints/reset-data-and-import-content/blueprint.json
@@ -29,7 +29,7 @@
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/starter-content.xml"
+				"url": "https://github.com/WordPress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/starter-content.xml"
 			}
 		},
 		{


### PR DESCRIPTION
testing to replace 
`https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/starter-content.xml`

with 
`https://github.com/WordPress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/starter-content.xml`

and see if the import still works. 