### PR TITLE
Update Kanso theme install

### DIFF
--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -33,7 +33,7 @@
 			"step": "installTheme",
 			"themeData": {
 				"resource":"url",
-			    "url": "https://github.com/richtabor/kanso?branch=main"
+			    "url": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip"
 			},
 			"options": {
 			  "activate": true

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -31,31 +31,30 @@
 		},
 		{
 			"step": "installTheme",
-			"themeZipFile": {
-				"resource": "url",
-				"url": "https://github-proxy.com/proxy/?repo=richtabor/kanso&branch=main"
+			"themeData": {
+			  "resource": "git:directory",
+			  "url": "https://github.com/richtabor/kanso",
+			  "ref": "main",
+			  "path": "/"
 			},
 			"options": {
-				"activate": true
+			  "activate": true
 			}
-		},
+		  },
 		{
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
-			}
-		},
-		{
-			"step": "setSiteOptions",
-			"options": {
-				"blogname": "Rich Tabor",
-				"blogdescription": "Multidisciplinary maker specializing in the intersection of product, design and engineering. Making WordPress.",
-				"show_on_front": "page",
-				"page_on_front": 6,
-				"page_for_posts": 2
+				"url": "https://github.com/WordPress/blueprints/blob/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
 			}
 		}
 	],
+	"siteOptions": {
+		"blogname": "Rich Tabor",
+		"blogdescription": "Multidisciplinary maker specializing in the intersection of product, design and engineering. Making WordPress.",
+		"show_on_front": "page",
+		"page_on_front": "6",
+		"page_for_posts": "2"
+	},
 	"plugins": ["todo-list-block", "markdown-comment-block"]
 }

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -33,7 +33,7 @@
 			"step": "installTheme",
 			"themeData": {
 				"resource":"url",
-			    "url": "https://github.com/richtabor/kanso"
+			    "url": "https://github.com/richtabor/kanso?branch=main"
 			},
 			"options": {
 			  "activate": true

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -33,10 +33,10 @@
 			"step": "installTheme",
 			"themeData": {
 				"resource":"url",
-			    "url": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip"
+				"url": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip"
 			},
 			"options": {
-			  "activate": true
+				"activate": true
 			}
 		  },
 		{

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -32,10 +32,8 @@
 		{
 			"step": "installTheme",
 			"themeData": {
-			  "resource": "git:directory",
-			  "url": "https://github.com/richtabor/kanso",
-			  "ref": "main",
-			  "path": "/"
+				"resource":"url",
+			    "url": "https://github.com/richtabor/kanso"
 			},
 			"options": {
 			  "activate": true


### PR DESCRIPTION
Fixes #95 

- Use `siteOptions` shorthand, 
- change types from numbers to string?
- no `https://raw.githubusercontent.com` for wrx url 
- no github-proxy.com anymore. 
- Use https://github.com/richtabor/kanso/archive/refs/heads/main.zip strait from the repo 