### PR TITLE
Update blueprint: admin notice

### DIFF
--- a/blueprints/admin-notice/blueprint.json
+++ b/blueprints/admin-notice/blueprint.json
@@ -9,7 +9,6 @@
 	"landingPage": "/wp-admin/plugins.php",
 	"login":true,
 	"steps": [
-		
 		{
 			"step": "writeFile",
 			"path": "/wordpress/wp-content/mu-plugins/bgnightly-notice.php",

--- a/blueprints/admin-notice/blueprint.json
+++ b/blueprints/admin-notice/blueprint.json
@@ -7,12 +7,9 @@
 		"categories": ["Admin", "notices"]
 	},
 	"landingPage": "/wp-admin/plugins.php",
+	"login":true,
 	"steps": [
-		{
-			"step": "login",
-			"username": "admin",
-			"password": "password"
-		},
+		
 		{
 			"step": "writeFile",
 			"path": "/wordpress/wp-content/mu-plugins/bgnightly-notice.php",


### PR DESCRIPTION
- Fixes #90 
- use login shorthand

This blueprint wouldn't get any value from using `writeFiles` as it only writes one file. 
