### PR TITLE
Adding demo to updating user meta

### DIFF
--- a/blueprints/user-meta/blueprint.json
+++ b/blueprints/user-meta/blueprint.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Creating a new user for the blog",
+		"description": "This is a simple example to update user meta data",
+		"author": "fellyph",
+		"categories": ["meta"]
+	},
+	"landingPage": "/wp-admin/users.php",
+	"login": true,
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "resetData"
+		},
+		{
+			"step": "updateUserMeta",
+			"meta": {
+				"first_name": "John",
+				"last_name": "Doe",
+				"admin_color": "midnight",
+				"nickname": "Johny",
+				"description": "This is the biographical info from John Doe."
+			},
+			"userId": 1
+		}
+	],
+	"siteOptions": {
+		"blogname": "John Boe Blog",
+		"blogdescription": "Everything about Blueprints"
+	}
+}


### PR DESCRIPTION
This pull request adds a separate demo for [updating User meta information](https://wordpress.github.io/wordpress-playground/guides/for-theme-developers#updateusermeta) from the playground documentation. The current demo uses the [same demo as install theme](https://github.com/WordPress/blueprints/blob/eb6da7dfa295a095eea2e424c0ae83a219803a8d/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json#L24), and lands at the site editor. 

This is not clear to users who are studying blueprints, so this demo separates the set to update the user's meta information and lands on the Manage User page. 