### PR TITLE
Removing networking references

### DIFF
--- a/blueprints/beta-rc/blueprint.json
+++ b/blueprints/beta-rc/blueprint.json
@@ -10,9 +10,6 @@
 		"php": "8.0",
 		"wp": "beta"
 	},
-	"features": {
-		"networking": true
-	},
 	"steps": [
 		{
 			"step": "login",

--- a/blueprints/create-block-theme/blueprint.json
+++ b/blueprints/create-block-theme/blueprint.json
@@ -7,9 +7,6 @@
 		"categories": ["Editor", "theme"]
 	},
 	"plugins": ["create-block-theme"],
-	"features": {
-		"networking": true
-	},
 	"login": true,
 	"landingPage": "/wp-admin/site-editor.php"
 }

--- a/blueprints/file-starter-content/blueprint.json
+++ b/blueprints/file-starter-content/blueprint.json
@@ -7,9 +7,6 @@
 		"categories": ["Themes", "Starter Content"]
 	},
 	"landingPage": "/",
-	"features": {
-		"networking": true
-	},
 	"steps": [
 		{
 			"step": "writeFile",

--- a/blueprints/friends-cors/blueprint.json
+++ b/blueprints/friends-cors/blueprint.json
@@ -7,9 +7,6 @@
 		"categories": ["rss", "social web"]
 	},
 	"landingPage": "/friends/?refresh&welcome",
-	"features": {
-		"networking": true
-	},
 	"plugins": ["friends", "activitypub"],
 	"siteOptions": {
 		"permalink_structure": "/%postname%/"

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -8,9 +8,6 @@
 	},
 	"landingPage": "/wp-admin/site-editor.php",
 	"login": true,
-	"features": {
-		"networking": true
-	},
 	"steps": [
 		{
 			"step": "resetData"

--- a/blueprints/showcase-plugin-with-media/blueprint.json
+++ b/blueprints/showcase-plugin-with-media/blueprint.json
@@ -10,9 +10,6 @@
 		"php": "8.3",
 		"wp": "6.7"
 	},
-	"features": {
-		"networking": true
-	},
 	"landingPage": "/",
 	"steps": [
 		{

--- a/blueprints/stylish-press/blueprint.json
+++ b/blueprints/stylish-press/blueprint.json
@@ -11,9 +11,6 @@
 		"php": "8.3",
 		"wp": "latest"
 	},
-	"features": {
-		"networking": true
-	},
 	"login": true,
 	"plugins": ["woocommerce"],
 	"steps": [

--- a/blueprints/theme-a11y-test/blueprint.json
+++ b/blueprints/theme-a11y-test/blueprint.json
@@ -10,9 +10,6 @@
 		"php": "8.0",
 		"wp": "beta"
 	},
-	"features": {
-		"networking": true
-	},
 	"login": true,
 	"plugins": ["create-block-theme"],
 	"steps": [

--- a/blueprints/theme-starter-content/blueprint.json
+++ b/blueprints/theme-starter-content/blueprint.json
@@ -7,9 +7,6 @@
 		"categories": ["Themes", "Starter Content"]
 	},
 	"landingPage": "/",
-	"features": {
-		"networking": true
-	},
 	"steps": [
 		{
 			"step": "installTheme",

--- a/blueprints/tt5-demo/blueprint.json
+++ b/blueprints/tt5-demo/blueprint.json
@@ -8,9 +8,6 @@
 	},
 	"landingPage": "/",
 	"login": true,
-	"features": {
-		"networking": true
-	},
 	"preferredVersions": {
 		"php": "8.0",
 		"wp": "beta"

--- a/blueprints/user-meta/blueprint.json
+++ b/blueprints/user-meta/blueprint.json
@@ -8,9 +8,6 @@
 	},
 	"landingPage": "/wp-admin/users.php",
 	"login": true,
-	"features": {
-		"networking": true
-	},
 	"steps": [
 		{
 			"step": "resetData"

--- a/blueprints/woocommerce-product-feed/blueprint.json
+++ b/blueprints/woocommerce-product-feed/blueprint.json
@@ -11,9 +11,6 @@
 		"php": "latest",
 		"wp": "latest"
 	},
-	"features": {
-		"networking": true
-	},
 	"login": true,
 	"plugins": ["woocommerce", "webtoffee-product-feed"],
 	"steps": [

--- a/docs/troubleshoot-debug-blueprints.md
+++ b/docs/troubleshoot-debug-blueprints.md
@@ -5,7 +5,6 @@ When you build Blueprints, you might run into issues. Here are tips and tools to
 ## Review common gotchas
 
 - Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you would need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('/wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
-- Enable `networking`: to access wp.org assets (themes, plugins, blocks, or patterns), or load a stylesheet using [add_editor_style()](https://developer.wordpress.org/reference/functions/add_editor_style/) (say, when [creating a custom block style](https://developer.wordpress.org/news/2023/02/creating-custom-block-styles-in-wordpress-themes)), you would need to enable the `networking` option: `"features": {"networking": true}`.
 
 ## Blueprints Builder
 


### PR DESCRIPTION
This pull request removes the references from previous Playground limitations. Now, the WordPress playground comes with networking access enabled by default. So the blueprints with references to that property were updated to remove the unnecessary call. 

The troubleshooting page was also updated, removing the mention around the previous network access limitation. 

 

