### PR TITLE
Friends Blueprint: CORS proxy is no longer needed

### DIFF
--- a/blueprints/friends-cors/blueprint.json
+++ b/blueprints/friends-cors/blueprint.json
@@ -2,27 +2,22 @@
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"meta": {
 		"title": "Feed Reader with the Friends Plugin",
-		"description": "By using the Friends plugin and a CORS proxy, you can read feeds from the web in Playground, and even via ActivityPub",
+		"description": "By using the Friends plugin, you can read feeds from the web in Playground, and even via ActivityPub",
 		"author": "akirk",
-		"categories": ["rss", "social web"]
+		"categories": [
+			"rss",
+			"social web"
+		]
 	},
 	"landingPage": "/friends/?refresh&welcome",
-	"plugins": ["friends", "activitypub"],
+	"plugins": [
+		"friends",
+		"activitypub"
+	],
 	"siteOptions": {
 		"permalink_structure": "/%postname%/"
 	},
 	"steps": [
-		{
-			"step": "writeFiles",
-			"writeToPath": "wordpress/wp-content/mu-plugins",
-			"filesTree": {
-				"resource": "literal:directory",
-				"name": "mu-plugins",
-				"files": {
-					"addFilter-0.php": "<?php add_action( 'requests-requests.before_request', function( &$url ) {\n$url = 'https://playground.wordpress.net/cors-proxy.php?' . $url;\n} );"
-				}
-			}
-		},
 		{
 			"step": "runPHP",
 			"code": "<?php require_once '/wordpress/wp-load.php';\nif ( class_exists('Friends\\Import')) {\nFriends\\Import::opml(\"<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?><opml version=\\\"2.0\\\">\n<head>\n<title>Subscriptions</title>\n</head>\n<body>\n<outline text=\\\"Subscriptions\\\" title=\\\"Subscriptions\\\">\n<outline type=\\\"rss\\\" text=\\\"Alex Kirk\\\" title=\\\"Alex Kirk\\\" xmlUrl=\\\"https://alex.kirk.at/feed/\\\" htmlUrl=\\\"https://alex.kirk.at/feed/\\\" />\n<outline type=\\\"rss\\\" text=\\\"Adam Zieli\u0144ski\\\" title=\\\"Adam Zieli\u0144ski\\\" xmlUrl=\\\"https://adamadam.blog/feed/\\\" htmlUrl=\\\"https://adamadam.blog/feed/\\\" />\n</outline>\n</body>\n</opml>\");\n}"


### PR DESCRIPTION
Since https://github.com/WordPress/wordpress-playground/pull/2076 the proxy is no longer needed and in fact breaks the feed fetching.