### PR TITLE
Bump PHP version to remove admin warning

### DIFF
--- a/blueprints/beta-rc/blueprint.json
+++ b/blueprints/beta-rc/blueprint.json
@@ -7,7 +7,7 @@
 		"categories": ["Testing"]
 	},
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "beta"
 	},
 	"steps": [

--- a/blueprints/install-plugin-from-gist/blueprint.json
+++ b/blueprints/install-plugin-from-gist/blueprint.json
@@ -8,7 +8,7 @@
 	"landingPage": "/wp-admin/plugins.php",
 	"preferredVersions": {
 		"wp": "beta",
-		"php": "8.0"
+		"php": "8.3"
 	},
 	"login": true,
 	"steps": [

--- a/blueprints/set-admin-color-scheme/blueprint.json
+++ b/blueprints/set-admin-color-scheme/blueprint.json
@@ -7,7 +7,7 @@
 		"categories": ["user meta"]
 	},
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "latest"
 	},
 	"landingPage": "/wp-admin/?welcome=0",

--- a/blueprints/theme-a11y-test/blueprint.json
+++ b/blueprints/theme-a11y-test/blueprint.json
@@ -7,7 +7,7 @@
 		"categories": ["themes", "content"]
 	},
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "beta"
 	},
 	"login": true,

--- a/blueprints/tt5-demo/blueprint.json
+++ b/blueprints/tt5-demo/blueprint.json
@@ -9,7 +9,7 @@
 	"landingPage": "/",
 	"login": true,
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "beta"
 	},
 	"steps": [


### PR DESCRIPTION
This pull request bumps the PHP version from the blueprints to 8.3 to remove the PHP warning inside the WordPress admin:

<img width="859" height="385" alt="472496263-c586c21f-7858-47a0-93b6-7b5268e58d1b" src="https://github.com/user-attachments/assets/1ddb8db4-612f-4c66-802b-38585b109e68" />


