### PR TITLE
Welcome Blueprint – copy adjustments

### DIFF
--- a/blueprints/welcome/blueprint.json
+++ b/blueprints/welcome/blueprint.json
@@ -21,7 +21,7 @@
 			"step": "importWxr",
 			"file": {
 				"resource": "bundled",
-				"url": "./content/blog-data.wxr"
+				"path": "./content/blog-data.wxr"
 			}
 		},
 		{

--- a/blueprints/welcome/blueprint.json
+++ b/blueprints/welcome/blueprint.json
@@ -20,8 +20,8 @@
 		{
 			"step": "importWxr",
 			"file": {
-				"resource": "url",
-				"url": "https://raw.githubusercontent.com/WordPress/blueprints/refs/heads/trunk/blueprints/welcome/content/blog-data.wxr"
+				"resource": "bundled",
+				"url": "./content/blog-data.wxr"
 			}
 		},
 		{

--- a/blueprints/welcome/content/blog-data.wxr
+++ b/blueprints/welcome/content/blog-data.wxr
@@ -167,10 +167,10 @@
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"metadata":{"name":"Run Playground in terminal","patternCategory":"general","remotePatternId":"14727-general"},"align":"full","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|60"},"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center","contentSize":"1120px"}} -->
+<!-- wp:group {"metadata":{"name":"Run Playground in your terminal","patternCategory":"general","remotePatternId":"14727-general"},"align":"full","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|60"},"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center","contentSize":"1120px"}} -->
 <div class="wp-block-group alignfull wp-embed-aspect-16-9 wp-has-aspect-ratio" id="general-section" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--60);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"backgroundColor":"contrast","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide has-contrast-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"wide"} -->
-<h2 class="wp-block-heading alignwide">Run Playground in terminal</h2>
+<h2 class="wp-block-heading alignwide">Run Playground in your terminal</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fixed","flexSize":"70%"}}} -->

--- a/blueprints/welcome/content/blog-data.wxr
+++ b/blueprints/welcome/content/blog-data.wxr
@@ -92,11 +92,11 @@
 		<content:encoded><![CDATA[<!-- wp:cover {"url":"https://raw.githubusercontent.com/WordPress/blueprints/refs/heads/trunk/blueprints/welcome/assets/imgs/cover-image-playground.png","id":77,"dimRatio":0,"isUserOverlayColor":true,"minHeight":100,"minHeightUnit":"vh","isDark":false,"sizeSlug":"full","layout":{"type":"constrained","contentSize":"1120px"}} -->
 <div class="wp-block-cover is-light" style="min-height:100vh"><img class="wp-block-cover__image-background wp-image-77 size-full" alt="" src="https://raw.githubusercontent.com/WordPress/blueprints/refs/heads/trunk/blueprints/welcome/assets/imgs/cover-image-playground.png" data-object-fit="cover"/><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained","justifyContent":"left","contentSize":"50%"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textAlign":"left","level":1,"fontSize":"xx-large"} -->
-<h1 class="wp-block-heading has-text-align-left has-xx-large-font-size">Run WordPress <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-accent-2-color">directly in your browser</mark></h1>
+<h1 class="wp-block-heading has-text-align-left has-xx-large-font-size">Hello from <mark style="background-color:rgba(0, 0, 0, 0)" class="has-inline-color has-accent-2-color">WordPress Playground!</mark></h1>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fixed","flexSize":"70%"}}} -->
-<p class="has-text-align-left">This website is perfect for training, demonstrating plugins and themes, and for testing purposes. It runs locally, so feel free to edit content, install plugins and play around. To restart, simply reload the browser.</p>
+<p class="has-text-align-left">This is Playground, a WordPress that runs client-side in your browser. It's perfect for training, demonstrating plugins and themes, and for testing purposes. It runs on your device – feel free to edit content, install plugins and play around. To restart, simply reload the page!</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"left"}} -->

--- a/blueprints/welcome/content/blog-data.wxr
+++ b/blueprints/welcome/content/blog-data.wxr
@@ -83,7 +83,7 @@
 </image> 
 
 		<item>
-		<title><![CDATA[Run WordPress directly in your browser]]></title>
+		<title><![CDATA[Hello from Playground!]]></title>
 		<link>/</link>
 		<pubDate>Tue, 17 Jun 2025 08:11:38 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
@@ -167,14 +167,14 @@
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"metadata":{"name":"Run playground on the terminal","patternCategory":"general","remotePatternId":"14727-general"},"align":"full","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|60"},"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center","contentSize":"1120px"}} -->
+<!-- wp:group {"metadata":{"name":"Run Playground in terminal","patternCategory":"general","remotePatternId":"14727-general"},"align":"full","className":"wp-embed-aspect-16-9 wp-has-aspect-ratio","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|60"},"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|40","right":"var:preset|spacing|40"},"blockGap":"var:preset|spacing|40"}},"layout":{"type":"constrained","justifyContent":"center","contentSize":"1120px"}} -->
 <div class="wp-block-group alignfull wp-embed-aspect-16-9 wp-has-aspect-ratio" id="general-section" style="margin-top:0;margin-bottom:var(--wp--preset--spacing--60);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"var:preset|spacing|60","top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"backgroundColor":"contrast","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide has-contrast-background-color has-background" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"align":"wide"} -->
-<h2 class="wp-block-heading alignwide">Run playground on the terminal</h2>
+<h2 class="wp-block-heading alignwide">Run Playground in terminal</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fixed","flexSize":"70%"}}} -->
-<p class="has-text-align-left">WordPress playground is available for developer, check their progress on plugins/themes developement and run test automation with the <a href="https://www.npmjs.com/package/@wp-playground/cli" target="_blank" rel="noopener noreferrer">WordPress playground CLI</a>.</p>
+<p class="has-text-align-left">Beyond the browser, WordPress Playground is also available as a <a href="https://www.npmjs.com/package/@wp-playground/cli" target="_blank" rel="noopener noreferrer">local CLI tool</a> for developers to develop their plugins, themes, run test automations.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:code {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-4"}}}},"backgroundColor":"accent-5","textColor":"accent-4"} -->

--- a/blueprints/welcome/content/blog-data.wxr
+++ b/blueprints/welcome/content/blog-data.wxr
@@ -174,7 +174,7 @@
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"align":"left","style":{"layout":{"selfStretch":"fixed","flexSize":"70%"}}} -->
-<p class="has-text-align-left">Beyond the browser, WordPress Playground is also available as a <a href="https://www.npmjs.com/package/@wp-playground/cli" target="_blank" rel="noopener noreferrer">local CLI tool</a> for developers to develop their plugins, themes, run test automations.</p>
+<p class="has-text-align-left">Beyond the browser, WordPress Playground is also available as a <a href="https://www.npmjs.com/package/@wp-playground/cli" target="_blank" rel="noopener noreferrer">local CLI tool</a> for developers to build their plugins, themes, and run test automations.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:code {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-4"}}}},"backgroundColor":"accent-5","textColor":"accent-4"} -->


### PR DESCRIPTION
Improves phrasing and wording in the default Playground Blueprint:

* `Run WordPress directly in your browser` -> `Hello from Playground!` as the main H1
* Capitalize the word Playground
* Explain Playground CLI is a separate tool

Also, the wxr file is now referenced as a bundled resource for easier testing – it no longer hardcodes the `trunk` branch.

After:

<img width="2672" height="2276" alt="CleanShot 2025-08-08 at 13 16 56@2x" src="https://github.com/user-attachments/assets/aaed1c80-fa08-4e33-954b-26e17eb086c5" />
