### PR TITLE
Removing landingPage property

### DIFF
--- a/blueprints/welcome/blueprint.json
+++ b/blueprints/welcome/blueprint.json
@@ -7,7 +7,6 @@
 		"categories": ["meta"]
 	},
 	"login": true,
-	"landingPage": "/wp-admin/site-editor.php",
 	"steps": [
 		{
 			"step": "runPHP",


### PR DESCRIPTION
The current Welcome page has the `landingPage` set as `"/wp-admin/site-editor.php"`, when the user accesses it via mobile. The page only displays the site editor sidebar:

<img width="718" height="903" alt="Screenshot 2025-08-18 at 09 03 49" src="https://github.com/user-attachments/assets/8ccfccfc-232f-48cc-a8aa-83665fa8f9f8" />

This pull request removes the property `landingPage` so that mobile users see the welcome page content:

<img width="720" height="904" alt="Screenshot 2025-08-18 at 09 09 26" src="https://github.com/user-attachments/assets/68245540-484c-499d-99ac-e2fa5b1b4ab4" />
