### PR TITLE
Add intl feature support to blueprint.json

### DIFF
--- a/blueprints/stylish-press/blueprint.json
+++ b/blueprints/stylish-press/blueprint.json
@@ -11,6 +11,9 @@
 		"php": "8.3",
 		"wp": "latest"
 	},
+	"features": {
+		"intl": true
+	},
 	"login": true,
 	"plugins": ["woocommerce"],
 	"steps": [

--- a/blueprints/woo-shipping/blueprint.json
+++ b/blueprints/woo-shipping/blueprint.json
@@ -7,6 +7,9 @@
 		"categories": ["woocommerce", "shipping", "flat_rate"]
 	},
 	"plugins": ["woocommerce"],
+	"features": {
+		"intl": true
+	},
 	"landingPage": "/wp-admin/admin.php?page=wc-settings&tab=shipping",
 	"steps": [
 		{


### PR DESCRIPTION
If you don't have `Intl` support, a blueprint with WooCommerce will throw this error:
```
[30-Sep-2025 13:52:57 UTC] PHP Fatal error:  Uncaught Error: Class "Symfony\Polyfill\Intl\Normalizer\Normalizer" not found in /wordpress/wp-content/plugins/wordpress-importer/php-toolkit/DataLiberation/vendor-patched/symfony/polyfill-intl-normalizer/bootstrap80.php:15
Stack trace:
#0 /wordpress/wp-includes/formatting.php(2): normalizer_is_normalized('\xC3\x85land Islands')
#1 /wordpress/wp-content/plugins/woocommerce/includes/wc-core-functions.php(1983): remove_accents('\xC3\x85land Islands')
#2 [internal function]: {closure}('\xC3\x85land Islands', 'AX')
#3 /wordpress/wp-content/plugins/woocommerce/includes/wc-core-functions.php(1980): array_walk(Array, Object(Closure))
#4 /wordpress/wp-content/plugins/woocommerce/includes/class-wc-countries.php(74): wc_asort_by_locale(Array)
#5 /wordpress/wp-content/plugins/woocommerce/includes/class-wc-countries.php(50): WC_Countries->get_countries()
#6 /wordpress/wp-content/plugins/woocommerce/includes/class-wc-countries.php(292): WC_Countries->__get('countries')
#7 /wordpress/wp-content/plugins/woocommerce/includes/wc-core-functions.php(1370): WC_Countries->get_allowed_countries()
#8 /wordpress/wp-content/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php(178): wc_get_customer_default_location()
#9 /wordpress/wp-content/plugins/woocommerce/includes/data-stores/class-wc-customer-data-store-session.php(167): WC_Customer_Data_Store_Session->set_defaults(Object(WC_Customer))
#10 /wordpress/wp-content/plugins/woocommerce/includes/class-wc-data-store.php(159): WC_Customer_Data_Store_Session->read(Object(WC_Customer))
#11 /wordpress/wp-content/plugins/woocommerce/includes/class-wc-customer.php(125): WC_Data_Store->read(Object(WC_Customer))
#12 /wordpress/wp-content/plugins/woocommerce/includes/class-woocommerce.php(1063): WC_Customer->__construct(0, true)
#13 /wordpress/wp-content/plugins/woocommerce/includes/wc-core-functions.php(2661): WooCommerce->initialize_cart()
#14 /wordpress/wp-content/plugins/woocommerce/includes/class-woocommerce.php(876): wc_load_cart()
#15 /wordpress/wp-includes/class-wp-hook.php(3): WooCommerce->init('')
#16 /wordpress/wp-includes/class-wp-hook.php(3): WP_Hook->apply_filters(NULL, Array)
#17 /wordpress/wp-includes/plugin.php(2): WP_Hook->do_action(Array)
#18 /wordpress/wp-settings.php(2): do_action('init')
#19 /wordpress/wp-config.php(102): require_once('/wordpress/wp-s...')
#20 /wordpress/wp-load.php(2): require_once('/wordpress/wp-c...')
#21 /internal/eval.php(3): require('/wordpress/wp-l...')
#22 {main}
  thrown in /wordpress/wp-content/plugins/wordpress-importer/php-toolkit/DataLiberation/vendor-patched/symfony/polyfill-intl-normalizer/bootstrap80.php on line 15
log-to-console.ts:41:12
```

Test: https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fblueprints%2Frefs%2Fheads%2Fadd-intl-stylishpress%2Fblueprints%2Fstylish-press%2Fblueprint.json&modal=error-report