### PR TITLE
[My WordPress] Adding Portuguese translation for about page and Welcome page

### DIFF
--- a/blueprints/my-wordpress/plugin/pt/about.html
+++ b/blueprints/my-wordpress/plugin/pt/about.html
@@ -1,0 +1,93 @@
+<!-- wp:paragraph {"fontSize":"medium"} -->
+<p class="has-medium-font-size">Este é um WordPress de verdade, rodando inteiramente no seu navegador. Sem servidor, sem conta e sem dados saindo do seu computador.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Como isso é possível?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Este WordPress funciona com o <a href="https://wordpress.org/playground/">WordPress Playground</a>, uma tecnologia que permite executar o WordPress diretamente no navegador usando WebAssembly. O seu conteúdo fica armazenado no armazenamento local do navegador.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">O que torna isso diferente</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li><strong>Realmente privado</strong> — Os seus dados nunca passam por um servidor. Eles existem apenas no seu dispositivo, no seu navegador.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><strong>Sem precisar de conta</strong> — Sem cadastro, sem e-mail, sem senha para lembrar. Basta abrir a página e já é sua.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><strong>Totalmente gratuito</strong> — Sem custos de hospedagem, sem assinaturas, sem pegadinhas.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><strong>WordPress completo</strong> — Esta não é uma demo limitada. Instale plugins, troque de tema, personalize tudo.</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Ideias de uso</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Por ser privado e persistente, este WordPress funciona bem para coisas que você talvez não queira publicar:</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li>Um diário pessoal ou anotações do dia a dia</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Rascunhos de posts antes de publicar em outro lugar</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Reunir receitas, favoritos ou material de pesquisa</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Aprender WordPress sem riscos</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Um espaço privado para organizar suas ideias</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Aprenda WordPress</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Quer saber mais sobre o que dá para fazer com o WordPress?</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list"><!-- wp:list-item -->
+<li><a href="https://wordpress.org/documentation/">Documentação do WordPress</a> — Guias e tutoriais oficiais</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://learn.wordpress.org/?locale=pt_BR">Learn WordPress</a> — Cursos e workshops gratuitos</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li><a href="https://developer.wordpress.org/block-editor/">Manual do Editor de Blocos</a> — Domine o editor</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Quando você estiver pronto para mais</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>Este WordPress no navegador é ótimo para uso pessoal. Quando quiser acessar o seu site de vários dispositivos, compartilhá-lo publicamente ou colaborar com outras pessoas, você pode exportar tudo e migrar para um WordPress hospedado. O que você construir aqui vai com você.</p>
+<!-- /wp:paragraph -->

--- a/blueprints/my-wordpress/plugin/pt/welcome-post.html
+++ b/blueprints/my-wordpress/plugin/pt/welcome-post.html
@@ -122,7 +122,7 @@
 				d="M6 5.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM4 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm11-.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5h-3a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM13 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2h-3a2 2 0 01-2-2V6zm5 8.5h-3a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5zM15 13a2 2 0 00-2 2v3a2 2 0 002 2h3a2 2 0 002-2v-3a2 2 0 00-2-2h-3zm-9 1.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5v-3a.5.5 0 01.5-.5zM4 15a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2v-3z"
 				fill-rule="evenodd"
 				clip-rule="evenodd"
-			></path></svg> Confira o menu de aplicativos</strong> — Procure este ícone na barra superior para instalar aplicativos, gerenciar backups e muito mais.
+			></path></svg> Confira o menu de aplicativos</strong> — Procure este ícone na barra superior para instalar aplicativos e muito mais.
 	</p>
 	<!-- /wp:paragraph -->
 </div>
@@ -179,11 +179,6 @@
         torna esse espaço bastante privado.
     </li>
     <li>
-        <strong>Faça backup do seu trabalho</strong> — Use o recurso de backup no menu superior
-        para salvar o seu site. Assim você pode restaurá-lo em outro navegador ou
-        se proteger contra a perda de dados do navegador.
-    </li>
-    <li>
         <strong>Pronto para ir mais longe?</strong> — Leve o seu Playground para uma hospedagem
         WordPress dedicada para acessá-lo de qualquer dispositivo, compartilhar publicamente ou
         convidar pessoas específicas para colaborar.
@@ -222,7 +217,6 @@
         para uso pessoal. O diretório completo de plugins do WordPress também está disponível
         caso queira explorar.
     </li>
-    <li><strong>Backups</strong> — Salve e restaure o seu site</li>
 	<li>
         <strong>Começar do zero</strong> — Reinicie o seu WordPress ou acesse
         <a href="https://playground.wordpress.net" target="_blank"

--- a/blueprints/my-wordpress/plugin/pt/welcome-post.html
+++ b/blueprints/my-wordpress/plugin/pt/welcome-post.html
@@ -1,0 +1,238 @@
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"left":"var:preset|spacing|40"},"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+<div
+	class="wp-block-columns"
+	style="
+		padding-top: var(--wp--preset--spacing--30);
+		padding-bottom: var(--wp--preset--spacing--30);
+	"
+>
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"#ffe8d6"},"border":{"radius":"12px"}}} -->
+		<div
+			class="wp-block-group has-background"
+			style="
+				border-radius: 12px;
+				background-color: #ffe8d6;
+				padding-top: var(--wp--preset--spacing--40);
+				padding-right: var(--wp--preset--spacing--30);
+				padding-bottom: var(--wp--preset--spacing--40);
+				padding-left: var(--wp--preset--spacing--30);
+			"
+		>
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center" style="font-size: 2.5rem">🎨</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">
+				<strong>Experimente sem medo</strong><br />Mude o que quiser, teste
+                coisas novas, deixe do seu jeito
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"#d4eaff"},"border":{"radius":"12px"}}} -->
+		<div
+			class="wp-block-group has-background"
+			style="
+				border-radius: 12px;
+				background-color: #d4eaff;
+				padding-top: var(--wp--preset--spacing--40);
+				padding-right: var(--wp--preset--spacing--30);
+				padding-bottom: var(--wp--preset--spacing--40);
+				padding-left: var(--wp--preset--spacing--30);
+			"
+		>
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center" style="font-size: 2.5rem">💾</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">
+				<strong>Fica salvo</strong><br />Suas mudanças são guardadas e
+                estarão aqui amanhã
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}},"color":{"background":"#e8def8"},"border":{"radius":"12px"}}} -->
+		<div
+			class="wp-block-group has-background"
+			style="
+				border-radius: 12px;
+				background-color: #e8def8;
+				padding-top: var(--wp--preset--spacing--40);
+				padding-right: var(--wp--preset--spacing--30);
+				padding-bottom: var(--wp--preset--spacing--40);
+				padding-left: var(--wp--preset--spacing--30);
+			"
+		>
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center" style="font-size: 2.5rem">🔒</p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">
+				<strong>É privado</strong><br />Roda no seu navegador, sem
+                precisar de conta
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"color":{"background":"#e8f5e9"},"border":{"radius":"12px"}}} -->
+<div
+	class="wp-block-group has-background"
+	style="
+		border-radius: 12px;
+		background-color: #e8f5e9;
+		padding-top: var(--wp--preset--spacing--40);
+		padding-right: var(--wp--preset--spacing--40);
+		padding-bottom: var(--wp--preset--spacing--40);
+		padding-left: var(--wp--preset--spacing--40);
+	"
+>
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">
+		<strong><svg
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+			width="20"
+			height="20"
+			aria-hidden="true"
+			focusable="false"
+			style="vertical-align: middle"
+		>
+			<path
+				d="M6 5.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM4 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm11-.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5h-3a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM13 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2h-3a2 2 0 01-2-2V6zm5 8.5h-3a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5zM15 13a2 2 0 00-2 2v3a2 2 0 002 2h3a2 2 0 002-2v-3a2 2 0 00-2-2h-3zm-9 1.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5v-3a.5.5 0 01.5-.5zM4 15a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2v-3z"
+				fill-rule="evenodd"
+				clip-rule="evenodd"
+			></path></svg> Confira o menu de aplicativos</strong> — Procure este ícone na barra superior para instalar aplicativos, gerenciar backups e muito mais.
+	</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","left":"var:preset|spacing|40","right":"var:preset|spacing|40"}},"color":{"background":"#f0f7ff"},"border":{"radius":"12px"}}} -->
+<div
+	class="wp-block-group has-background"
+	style="
+		border-radius: 12px;
+		background-color: #f0f7ff;
+		padding-top: var(--wp--preset--spacing--40);
+		padding-right: var(--wp--preset--spacing--40);
+		padding-bottom: var(--wp--preset--spacing--40);
+		padding-left: var(--wp--preset--spacing--40);
+	"
+>
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">
+		<strong>⭐ Adicione esta página aos favoritos</strong> — Este agora é o seu WordPress. Salve
+        nos favoritos para voltar com facilidade.
+	</p>
+	<!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">O que você pode fazer aqui?</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+	<li>
+		<strong>Um espaço só seu</strong> — O WordPress está por trás de boa parte da web,
+        mas aqui ele é só para você. Use como caderno de anotações, espaço para projetos ou
+        um lugar para soltar a criatividade—não precisa publicar nada.
+	</li>
+	<li>
+		<strong>Totalmente personalizável</strong> — Troque o tema, organize tudo
+        do jeito que preferir. Você vai aprender WordPress naturalmente enquanto usa.
+	</li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">O que você precisa saber</h2>
+<!-- /wp:heading -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+	<li>
+        <strong>Está vinculado a este navegador</strong> — O seu Playground fica guardado
+        no armazenamento deste navegador, então você não pode acessá-lo de outros dispositivos. Isso
+        torna esse espaço bastante privado.
+    </li>
+    <li>
+        <strong>Faça backup do seu trabalho</strong> — Use o recurso de backup no menu superior
+        para salvar o seu site. Assim você pode restaurá-lo em outro navegador ou
+        se proteger contra a perda de dados do navegador.
+    </li>
+    <li>
+        <strong>Pronto para ir mais longe?</strong> — Leve o seu Playground para uma hospedagem
+        WordPress dedicada para acessá-lo de qualquer dispositivo, compartilhar publicamente ou
+        convidar pessoas específicas para colaborar.
+    </li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:heading -->
+<h2 class="wp-block-heading">O menu superior</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph -->
+<p>
+	Procure o ícone de grade (<svg
+		viewBox="0 0 24 24"
+		xmlns="http://www.w3.org/2000/svg"
+		width="20"
+		height="20"
+		aria-hidden="true"
+		focusable="false"
+		style="vertical-align: middle"
+	>
+		<path
+			d="M6 5.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM4 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm11-.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5h-3a.5.5 0 01-.5-.5V6a.5.5 0 01.5-.5zM13 6a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2h-3a2 2 0 01-2-2V6zm5 8.5h-3a.5.5 0 00-.5.5v3a.5.5 0 00.5.5h3a.5.5 0 00.5-.5v-3a.5.5 0 00-.5-.5zM15 13a2 2 0 00-2 2v3a2 2 0 002 2h3a2 2 0 002-2v-3a2 2 0 00-2-2h-3zm-9 1.5h3a.5.5 0 01.5.5v3a.5.5 0 01-.5.5H6a.5.5 0 01-.5-.5v-3a.5.5 0 01.5-.5zM4 15a2 2 0 012-2h3a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2v-3z"
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+		></path></svg
+	>) na barra superior. A partir dele você pode:
+</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul class="wp-block-list">
+	<li>
+        <strong>Instalar aplicativos</strong> — Selecionamos alguns plugins que funcionam bem
+        para uso pessoal. O diretório completo de plugins do WordPress também está disponível
+        caso queira explorar.
+    </li>
+    <li><strong>Backups</strong> — Salve e restaure o seu site</li>
+	<li>
+        <strong>Começar do zero</strong> — Reinicie o seu WordPress ou acesse
+        <a href="https://playground.wordpress.net" target="_blank"
+            >playground.wordpress.net</a
+        >
+        para experimentos rápidos e temporários
+    </li>
+</ul>
+<!-- /wp:list -->
+
+<!-- wp:paragraph -->
+<p>Aproveite o seu WordPress!</p>
+<!-- /wp:paragraph -->

--- a/blueprints/my-wordpress/plugin/translations.json
+++ b/blueprints/my-wordpress/plugin/translations.json
@@ -8,6 +8,9 @@
 		},
 		"es_ES": {
 			"contentDir": "es"
+		},
+		"pt_BR": {
+			"contentDir": "pt"
 		}
 	},
 	"fallbacks": {
@@ -26,6 +29,10 @@
 		"es_PE": "es_ES",
 		"es_PR": "es_ES",
 		"es_UY": "es_ES",
-		"es_VE": "es_ES"
+		"es_VE": "es_ES",
+
+		"pt_PT": "pt_BR",
+		"pt_AO": "pt_BR",
+		"pt_MZ": "pt_BR"
 	}
 }


### PR DESCRIPTION
This pull request adds Brazilian Portuguese (pt_BR) localization support to the My WordPress plugin and introduces the initial Portuguese content files. The main changes include updating the translations configuration to recognize the new language, setting up fallbacks for other Portuguese dialects, and providing localized content for the about page and welcome post.

Localization support:

* Added `pt_BR` (Brazilian Portuguese) to the `languages` section in `translations.json`, mapping it to the `pt` content directory.
* Set up fallbacks in `translations.json` so that `pt_PT`, `pt_AO`, and `pt_MZ` all use the `pt_BR` content.

Steps to test
1. Pull the branch locally 
2. Run the blueprints located at `blueprints/my-wordpress/blueprint.json` with the locale set to Portuguese
3. Check the translation on the page