### PR TITLE
Add blueprint to enable Gutenberg Guidelines experiment

### DIFF
--- a/blueprints/gutenberg-guidelines/blueprint.json
+++ b/blueprints/gutenberg-guidelines/blueprint.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Gutenberg Guidelines Experiment enabled",
+		"author": "smithjw1",
+		"description": "Enables the Gutenberg Guidelines experiment from the Gutenberg Experiments page",
+		"categories": ["Gutenberg", "Experiments"]
+	},
+	"landingPage": "/wp-admin/admin.php?page=guidelines-wp-admin",
+	"login": true,
+	"plugins": ["gutenberg"],
+	"steps": [
+		{
+			"step": "runPHP",
+			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-guidelines' => true ) );"
+		}
+	]
+}


### PR DESCRIPTION
 ## Summary                                                

  Gutenberg Experiments page and drops the user directly on the Guidelines admin
   screen.                                                                      
                                                                                
  ## What it does                                           
                 
  1. Installs the Gutenberg plugin
  2. Runs a PHP snippet to toggle on the `gutenberg-guidelines` key in the
  `gutenberg-experiments` option                                          
  3. Lands the logged-in user on `/wp-admin/admin.php?page=guidelines-wp-admin` 
                                                                               
  ## Testing                                                                    
                                                            
  Preview in WordPress Playground:
  https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.
  com/smithjw1/blueprints/trunk/blueprints/gutenberg-guidelines/blueprint.json  
                                                                                
  - [x] Gutenberg plugin is active                          
  - [x] **Gutenberg** → **Experiments** shows the Guidelines experiment checked
  - [x] Landing page is `/wp-admin/admin.php?page=guidelines-wp-admin`