### PR TITLE
Add My WordPress submission guide

### DIFF
--- a/.github/workflows/validate-my-wordpress-json.yml
+++ b/.github/workflows/validate-my-wordpress-json.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         paths:
             - ".github/workflows/validate-my-wordpress-json.yml"
+            - "package-lock.json"
+            - "package.json"
+            - "scripts/validate-my-wordpress-json.js"
             - "apps.json"
             - "apps/*.json"
             - "blueprints/my-wordpress/**/*.json"
@@ -12,6 +15,9 @@ on:
             - trunk
         paths:
             - ".github/workflows/validate-my-wordpress-json.yml"
+            - "package-lock.json"
+            - "package.json"
+            - "scripts/validate-my-wordpress-json.js"
             - "apps.json"
             - "apps/*.json"
             - "blueprints/my-wordpress/**/*.json"
@@ -33,121 +39,8 @@ jobs:
               with:
                   node-version: 20
 
-            - name: Install JSON Schema validator
-              run: npm install --no-save --package-lock=false ajv ajv-formats
+            - name: Install dependencies
+              run: npm ci
 
             - name: Validate JSON and schemas
-              run: |
-                  node <<'JS'
-                  const fs = require('fs');
-                  const path = require('path');
-                  const Ajv = require('ajv');
-                  const Ajv2020 = require('ajv/dist/2020');
-                  const addFormats = require('ajv-formats');
-
-                  function listJsonFiles(dir, recursive = false) {
-                    if (!fs.existsSync(dir)) {
-                      return [];
-                    }
-
-                    const files = [];
-                    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                      const entryPath = path.join(dir, entry.name);
-                      if (entry.isDirectory() && recursive) {
-                        files.push(...listJsonFiles(entryPath, true));
-                      } else if (entry.isFile() && entry.name.endsWith('.json')) {
-                        files.push(entryPath);
-                      }
-                    }
-                    return files;
-                  }
-
-                  function readJson(filePath) {
-                    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-                  }
-
-                  function githubError(filePath, message) {
-                    console.log(`::error file=${filePath}::${message}`);
-                  }
-
-                  function ajvPath(instancePath) {
-                    return instancePath ? instancePath.slice(1).replaceAll('/', '.') : '<root>';
-                  }
-
-                  async function fetchJson(url) {
-                    const response = await fetch(url);
-                    if (!response.ok) {
-                      throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
-                    }
-                    return response.json();
-                  }
-
-                  async function main() {
-                    const jsonFiles = [
-                      'apps.json',
-                      ...listJsonFiles('apps'),
-                      ...listJsonFiles('blueprints/my-wordpress', true),
-                    ].sort();
-
-                    for (const filePath of jsonFiles) {
-                      readJson(filePath);
-                      console.log(`Valid JSON: ${filePath}`);
-                    }
-
-                    let failed = false;
-
-                    const blueprintSchema = await fetchJson(process.env.BLUEPRINT_SCHEMA_URL);
-                    const blueprintAjv = new Ajv({ allErrors: true, strict: false, validateSchema: false });
-                    const validateBlueprint = blueprintAjv.compile(blueprintSchema);
-                    const blueprintFiles = [
-                      'blueprints/my-wordpress/blueprint.json',
-                      ...listJsonFiles('apps'),
-                    ].sort();
-
-                    for (const filePath of blueprintFiles) {
-                      const valid = validateBlueprint(readJson(filePath));
-                      if (valid) {
-                        console.log(`Valid Blueprint schema: ${filePath}`);
-                        continue;
-                      }
-
-                      failed = true;
-                      for (const error of validateBlueprint.errors || []) {
-                        githubError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
-                      }
-                    }
-
-                    const catalogAjv = new Ajv2020({ allErrors: true, strict: false });
-                    addFormats(catalogAjv);
-                    const schemaBaseUrl = process.env.MY_APPS_SCHEMA_BASE_URL;
-                    const catalogChecks = {
-                      'apps.json': `${schemaBaseUrl}/apps.schema.json`,
-                      'blueprints/my-wordpress/plugins.json': `${schemaBaseUrl}/plugins.schema.json`,
-                      'blueprints/my-wordpress/recipes.json': `${schemaBaseUrl}/recipes.schema.json`,
-                    };
-
-                    for (const [filePath, schemaUrl] of Object.entries(catalogChecks)) {
-                      const schema = await fetchJson(schemaUrl);
-                      const validateCatalog = catalogAjv.compile(schema);
-                      const valid = validateCatalog(readJson(filePath));
-                      if (valid) {
-                        console.log(`Valid My Apps catalog schema: ${filePath}`);
-                        continue;
-                      }
-
-                      failed = true;
-                      for (const error of validateCatalog.errors || []) {
-                        githubError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
-                      }
-                    }
-
-                    if (failed) {
-                      process.exit(1);
-                    }
-                  }
-
-                  main().catch((error) => {
-                    console.error(error);
-                    process.exit(1);
-                  });
-                  JS
+              run: npm run validate:my-wordpress-json

--- a/.github/workflows/validate-my-wordpress-json.yml
+++ b/.github/workflows/validate-my-wordpress-json.yml
@@ -18,6 +18,7 @@ on:
 
 env:
     BLUEPRINT_SCHEMA_URL: "https://raw.githubusercontent.com/WordPress/wordpress-playground/trunk/packages/playground/blueprints/public/blueprint-schema.json"
+    MY_APPS_SCHEMA_BASE_URL: "https://raw.githubusercontent.com/akirk/my-apps/main/schemas"
 
 jobs:
     validate_json:
@@ -27,73 +28,126 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
 
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+
             - name: Install JSON Schema validator
-              run: python -m pip install jsonschema
+              run: npm install --no-save --package-lock=false ajv ajv-formats
 
-            - name: Validate JSON syntax
+            - name: Validate JSON and schemas
               run: |
-                  python - <<'PY'
-                  import json
-                  from pathlib import Path
+                  node <<'JS'
+                  const fs = require('fs');
+                  const path = require('path');
+                  const Ajv = require('ajv');
+                  const Ajv2020 = require('ajv/dist/2020');
+                  const addFormats = require('ajv-formats');
 
-                  patterns = [
+                  function listJsonFiles(dir, recursive = false) {
+                    if (!fs.existsSync(dir)) {
+                      return [];
+                    }
+
+                    const files = [];
+                    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                      const entryPath = path.join(dir, entry.name);
+                      if (entry.isDirectory() && recursive) {
+                        files.push(...listJsonFiles(entryPath, true));
+                      } else if (entry.isFile() && entry.name.endsWith('.json')) {
+                        files.push(entryPath);
+                      }
+                    }
+                    return files;
+                  }
+
+                  function readJson(filePath) {
+                    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+                  }
+
+                  function githubError(filePath, message) {
+                    console.log(`::error file=${filePath}::${message}`);
+                  }
+
+                  function ajvPath(instancePath) {
+                    return instancePath ? instancePath.slice(1).replaceAll('/', '.') : '<root>';
+                  }
+
+                  async function fetchJson(url) {
+                    const response = await fetch(url);
+                    if (!response.ok) {
+                      throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+                    }
+                    return response.json();
+                  }
+
+                  async function main() {
+                    const jsonFiles = [
                       'apps.json',
-                      'apps/*.json',
-                      'blueprints/my-wordpress/**/*.json',
-                  ]
+                      ...listJsonFiles('apps'),
+                      ...listJsonFiles('blueprints/my-wordpress', true),
+                    ].sort();
 
-                  files = []
-                  for pattern in patterns:
-                      files.extend(Path('.').glob(pattern))
+                    for (const filePath of jsonFiles) {
+                      readJson(filePath);
+                      console.log(`Valid JSON: ${filePath}`);
+                    }
 
-                  for path in sorted(set(files)):
-                      with path.open(encoding='utf-8') as file:
-                          json.load(file)
-                      print(f'Valid JSON: {path}')
-                  PY
+                    let failed = false;
 
-            - name: Validate Blueprint schemas
-              run: |
-                  python - <<'PY'
-                  import json
-                  import os
-                  import sys
-                  import urllib.request
-                  from pathlib import Path
+                    const blueprintSchema = await fetchJson(process.env.BLUEPRINT_SCHEMA_URL);
+                    const blueprintAjv = new Ajv({ allErrors: true, strict: false, validateSchema: false });
+                    const validateBlueprint = blueprintAjv.compile(blueprintSchema);
+                    const blueprintFiles = [
+                      'blueprints/my-wordpress/blueprint.json',
+                      ...listJsonFiles('apps'),
+                    ].sort();
 
-                  from jsonschema import Draft7Validator
+                    for (const filePath of blueprintFiles) {
+                      const valid = validateBlueprint(readJson(filePath));
+                      if (valid) {
+                        console.log(`Valid Blueprint schema: ${filePath}`);
+                        continue;
+                      }
 
-                  schema_url = os.environ['BLUEPRINT_SCHEMA_URL']
-                  with urllib.request.urlopen(schema_url) as response:
-                      schema = json.load(response)
+                      failed = true;
+                      for (const error of validateBlueprint.errors || []) {
+                        githubError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
+                      }
+                    }
 
-                  Draft7Validator.check_schema(schema)
-                  validator = Draft7Validator(schema)
+                    const catalogAjv = new Ajv2020({ allErrors: true, strict: false });
+                    addFormats(catalogAjv);
+                    const schemaBaseUrl = process.env.MY_APPS_SCHEMA_BASE_URL;
+                    const catalogChecks = {
+                      'apps.json': `${schemaBaseUrl}/apps.schema.json`,
+                      'blueprints/my-wordpress/plugins.json': `${schemaBaseUrl}/plugins.schema.json`,
+                      'blueprints/my-wordpress/recipes.json': `${schemaBaseUrl}/recipes.schema.json`,
+                    };
 
-                  blueprint_files = [
-                      Path('blueprints/my-wordpress/blueprint.json'),
-                      *Path('apps').glob('*.json'),
-                  ]
+                    for (const [filePath, schemaUrl] of Object.entries(catalogChecks)) {
+                      const schema = await fetchJson(schemaUrl);
+                      const validateCatalog = catalogAjv.compile(schema);
+                      const valid = validateCatalog(readJson(filePath));
+                      if (valid) {
+                        console.log(`Valid My Apps catalog schema: ${filePath}`);
+                        continue;
+                      }
 
-                  failed = False
-                  for path in sorted(blueprint_files):
-                      with path.open(encoding='utf-8') as file:
-                          data = json.load(file)
+                      failed = true;
+                      for (const error of validateCatalog.errors || []) {
+                        githubError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
+                      }
+                    }
 
-                      errors = sorted(
-                          validator.iter_errors(data),
-                          key=lambda error: list(error.absolute_path),
-                      )
+                    if (failed) {
+                      process.exit(1);
+                    }
+                  }
 
-                      if not errors:
-                          print(f'Valid Blueprint schema: {path}')
-                          continue
-
-                      failed = True
-                      for error in errors:
-                          location = '/'.join(str(part) for part in error.absolute_path) or '<root>'
-                          print(f'::error file={path}::{location}: {error.message}')
-
-                  if failed:
-                      sys.exit(1)
-                  PY
+                  main().catch((error) => {
+                    console.error(error);
+                    process.exit(1);
+                  });
+                  JS

--- a/.github/workflows/validate-my-wordpress-json.yml
+++ b/.github/workflows/validate-my-wordpress-json.yml
@@ -1,0 +1,47 @@
+name: Validate My WordPress JSON
+
+on:
+    pull_request:
+        paths:
+            - ".github/workflows/validate-my-wordpress-json.yml"
+            - "apps.json"
+            - "apps/*.json"
+            - "blueprints/my-wordpress/**/*.json"
+    push:
+        branches:
+            - trunk
+        paths:
+            - ".github/workflows/validate-my-wordpress-json.yml"
+            - "apps.json"
+            - "apps/*.json"
+            - "blueprints/my-wordpress/**/*.json"
+
+jobs:
+    validate_json:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Validate JSON syntax
+              run: |
+                  python - <<'PY'
+                  import json
+                  from pathlib import Path
+
+                  patterns = [
+                      'apps.json',
+                      'apps/*.json',
+                      'blueprints/my-wordpress/**/*.json',
+                  ]
+
+                  files = []
+                  for pattern in patterns:
+                      files.extend(Path('.').glob(pattern))
+
+                  for path in sorted(set(files)):
+                      with path.open(encoding='utf-8') as file:
+                          json.load(file)
+                      print(f'Valid JSON: {path}')
+                  PY

--- a/.github/workflows/validate-my-wordpress-json.yml
+++ b/.github/workflows/validate-my-wordpress-json.yml
@@ -16,6 +16,9 @@ on:
             - "apps/*.json"
             - "blueprints/my-wordpress/**/*.json"
 
+env:
+    BLUEPRINT_SCHEMA_URL: "https://raw.githubusercontent.com/WordPress/wordpress-playground/trunk/packages/playground/blueprints/public/blueprint-schema.json"
+
 jobs:
     validate_json:
         runs-on: ubuntu-latest
@@ -23,6 +26,9 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+
+            - name: Install JSON Schema validator
+              run: python -m pip install jsonschema
 
             - name: Validate JSON syntax
               run: |
@@ -44,4 +50,50 @@ jobs:
                       with path.open(encoding='utf-8') as file:
                           json.load(file)
                       print(f'Valid JSON: {path}')
+                  PY
+
+            - name: Validate Blueprint schemas
+              run: |
+                  python - <<'PY'
+                  import json
+                  import os
+                  import sys
+                  import urllib.request
+                  from pathlib import Path
+
+                  from jsonschema import Draft7Validator
+
+                  schema_url = os.environ['BLUEPRINT_SCHEMA_URL']
+                  with urllib.request.urlopen(schema_url) as response:
+                      schema = json.load(response)
+
+                  Draft7Validator.check_schema(schema)
+                  validator = Draft7Validator(schema)
+
+                  blueprint_files = [
+                      Path('blueprints/my-wordpress/blueprint.json'),
+                      *Path('apps').glob('*.json'),
+                  ]
+
+                  failed = False
+                  for path in sorted(blueprint_files):
+                      with path.open(encoding='utf-8') as file:
+                          data = json.load(file)
+
+                      errors = sorted(
+                          validator.iter_errors(data),
+                          key=lambda error: list(error.absolute_path),
+                      )
+
+                      if not errors:
+                          print(f'Valid Blueprint schema: {path}')
+                          continue
+
+                      failed = True
+                      for error in errors:
+                          location = '/'.join(str(part) for part in error.absolute_path) or '<root>'
+                          print(f'::error file={path}::{location}: {error.message}')
+
+                  if failed:
+                      sys.exit(1)
                   PY

--- a/blueprints/my-wordpress/README.md
+++ b/blueprints/my-wordpress/README.md
@@ -1,0 +1,8 @@
+# My WordPress
+
+My WordPress is a Blueprint for a persistent WordPress Playground welcome experience powered by the My Apps launcher and app store.
+
+Contribution guides:
+
+- [Submitting Plugins and Apps](./submitting-plugins-and-apps.md)
+- [Contributing Recipes](./contributing-recipes.md)

--- a/blueprints/my-wordpress/README.md
+++ b/blueprints/my-wordpress/README.md
@@ -1,8 +1,8 @@
 # My WordPress
 
-My WordPress is a Blueprint for a persistent WordPress Playground welcome experience powered by the My Apps launcher and app store.
+My WordPress is a Blueprint for a persistent WordPress Playground welcome experience used by [my.wordpress.net](https://my.wordpress.net/) and powered by the [My Apps](https://github.com/akirk/my-apps) launcher and app store.
 
-Contribution guides:
+To contribute to My WordPress, start with the guide that matches your change:
 
-- [Submitting Plugins and Apps](./submitting-plugins-and-apps.md)
-- [Contributing Recipes](./contributing-recipes.md)
+- [Submitting Plugins and Apps](./submitting-plugins-and-apps.md): add a plugin recommendation or app Blueprint to the curated app store.
+- [Contributing Recipes](./contributing-recipes.md): add or update a guided workflow in `recipes.json`.

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -1,0 +1,159 @@
+# Contributing Recipes for My WordPress
+
+Recipes are guided workflows shown by My WordPress. They are not a general plugin or app catalog. A good recipe helps someone complete a real task, explains why each step matters, and points to the exact app, plugin, or admin screen needed next.
+
+Recipe contributions live in `blueprints/my-wordpress/recipes.json`. If a recipe depends on a new plugin or app, contribute that entry first or include it in the same pull request with a clear explanation. For app and plugin submissions, see [Submitting Plugins and Apps](./submitting-plugins-and-apps.md).
+
+## When to Add a Recipe
+
+Add or update a recipe when the workflow is broader than installing one app.
+
+Good recipe candidates:
+
+- They have a clear outcome, such as building a family blog, setting up a reading hub, or importing personal data.
+- They combine multiple steps into a useful sequence.
+- They include enough context for a user to decide whether the workflow fits their site.
+- They leave users at a concrete next action, not a vague recommendation.
+
+Avoid recipe changes when the contribution is only a single app listing, a plugin recommendation without a workflow, or a promotional description that does not help users act.
+
+## Recipe Structure
+
+Each top-level key in `recipes.json` is a stable recipe slug. A recipe should include:
+
+- `title`: short action-oriented name.
+- `tagline`: one-line promise shown with the recipe.
+- `description`: user-facing summary of the workflow and why it matters.
+- `icon`: short visual marker for the recipe card.
+- `gradient`: CSS gradient used by the recipe card.
+- `learn_more`: optional URL for deeper background.
+- `steps`: ordered list of actions.
+
+Example:
+
+```json
+{
+	"example-workflow": {
+		"title": "Build an Example Workflow",
+		"tagline": "A short promise for the user",
+		"description": "Explain what the workflow helps users do and why the steps belong together.",
+		"icon": "E",
+		"gradient": "linear-gradient(135deg, #2563eb 0%, #16a34a 100%)",
+		"learn_more": "https://example.com/example-workflow",
+		"steps": []
+	}
+}
+```
+
+## Step Types
+
+Every step should have a `type`, `title`, and `description`. Use `optional: true` for useful additions that are not required for the core workflow. Use `context` when a step only applies in a specific environment, such as `self-hosted`.
+
+Use a `note` step for instructions or admin screens:
+
+```json
+{
+	"type": "note",
+	"title": "Write the first post",
+	"description": "Start with one post so the rest of the setup has something real to support.",
+	"url": "/wp-admin/post-new.php",
+	"url_label": "Open New Post"
+}
+```
+
+Use a `plugin` step for an entry from `blueprints/my-wordpress/plugins.json`:
+
+```json
+{
+	"type": "plugin",
+	"slug": "example-plugin",
+	"title": "Install Example Plugin",
+	"description": "Explain exactly why this plugin belongs in the workflow.",
+	"optional": true
+}
+```
+
+Use an `app` step for a Blueprint registered in `apps.json`:
+
+```json
+{
+	"type": "app",
+	"path": "apps/example-app.json",
+	"title": "Install Example App",
+	"description": "Explain what this app unlocks for the workflow."
+}
+```
+
+Use a `github` step for a plugin installed from a GitHub repository:
+
+```json
+{
+	"type": "github",
+	"repo": "example/example-plugin",
+	"title": "Install Example Plugin",
+	"description": "Explain why this GitHub-hosted plugin is part of the workflow.",
+	"optional": true
+}
+```
+
+## Writing Guidelines
+
+Keep recipes practical and specific:
+
+- Write for someone setting up their own WordPress, not for reviewers.
+- Keep titles short and action-oriented.
+- Explain the purpose of each step, not just what button it installs.
+- Put required setup before optional enhancements.
+- Use optional steps sparingly so the main path stays clear.
+- Prefer existing plugin or app entries over duplicating install instructions.
+- Keep external-service, paid-feature, privacy, or account requirements visible in the relevant step description.
+
+## Test the Submission
+
+Before opening a pull request:
+
+1. Validate `recipes.json`:
+
+	```bash
+	python3 -m json.tool blueprints/my-wordpress/recipes.json >/dev/null
+	```
+
+2. Format it with the repository's Prettier settings if available:
+
+	```bash
+	npx prettier --write blueprints/my-wordpress/recipes.json
+	```
+
+3. Check every referenced dependency:
+
+	- `plugin` steps use slugs that exist in `blueprints/my-wordpress/plugins.json`.
+	- `app` steps use paths that exist in `apps.json`.
+	- `github` steps use reachable `owner/repo` values.
+	- `note` steps with URLs open a useful screen.
+
+4. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
+
+## Open the Pull Request
+
+Submit a pull request against the `wordpress/blueprints` repository.
+
+Include:
+
+- The workflow the recipe helps users complete.
+- Any new plugin or app entries the recipe depends on.
+- Notes about external services, API keys, paid features, tracking, or privacy-sensitive behavior.
+- A short explanation of why each required step belongs in the sequence.
+
+Keep the pull request focused. A recipe-only submission should usually touch `blueprints/my-wordpress/recipes.json` and, if needed, the plugin or app files required by the recipe.
+
+## Review Checklist
+
+Reviewers should be able to answer yes to these questions:
+
+- Does the recipe help users complete a real workflow?
+- Are the required steps ordered correctly?
+- Are optional steps clearly optional?
+- Do plugin, app, and GitHub references resolve?
+- Are dependencies and external services disclosed?
+- Is the writing clear enough for someone who has not seen the pull request?
+- Is `recipes.json` valid and consistently formatted?

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -127,7 +127,7 @@ Before opening a pull request:
 
 3. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
 
-The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas.
+The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas. You can run the same check locally with `npm run validate:my-wordpress-json`.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -2,7 +2,7 @@
 
 Recipes are guided workflows shown by My WordPress. They are not a general plugin or app catalog. A good recipe helps someone complete a real task, explains why each step matters, and points to the exact app, plugin, or admin screen needed next.
 
-Recipe contributions live in `blueprints/my-wordpress/recipes.json`. If a recipe depends on a new plugin or app, contribute that entry first or include it in the same pull request with a clear explanation. For app and plugin submissions, see [Submitting Plugins and Apps](./submitting-plugins-and-apps.md).
+Recipe contributions live in [blueprints/my-wordpress/recipes.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/recipes.json). If a recipe depends on a new plugin or app, contribute that entry first or include it in the same pull request with a clear explanation. For app and plugin submissions, see [Submitting Plugins and Apps](./submitting-plugins-and-apps.md).
 
 ## When to Add a Recipe
 
@@ -19,7 +19,7 @@ Avoid recipe changes when the contribution is only a single app listing, a plugi
 
 ## Recipe Structure
 
-Each top-level key in `recipes.json` is a stable recipe slug. A recipe should include:
+Each top-level key in [recipes.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/recipes.json) is a stable recipe slug. A recipe should include:
 
 - `title`: short action-oriented name.
 - `tagline`: one-line promise shown with the recipe.
@@ -61,7 +61,7 @@ Use a `note` step for instructions or admin screens:
 }
 ```
 
-Use a `plugin` step for an entry from `blueprints/my-wordpress/plugins.json`:
+Use a `plugin` step for an entry from [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json):
 
 ```json
 {
@@ -73,7 +73,7 @@ Use a `plugin` step for an entry from `blueprints/my-wordpress/plugins.json`:
 }
 ```
 
-Use an `app` step for a Blueprint registered in `apps.json`:
+Use an `app` step for a Blueprint registered in [apps.json](https://github.com/WordPress/blueprints/blob/trunk/apps.json):
 
 ```json
 {
@@ -112,7 +112,7 @@ Keep recipes practical and specific:
 
 Before opening a pull request:
 
-1. Format `recipes.json` with the repository's Prettier settings if available:
+1. Format [recipes.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/recipes.json) with the repository's Prettier settings if available:
 
 	```bash
 	npx prettier --write blueprints/my-wordpress/recipes.json
@@ -120,8 +120,8 @@ Before opening a pull request:
 
 2. Check every referenced dependency:
 
-	- `plugin` steps use slugs that exist in `blueprints/my-wordpress/plugins.json`.
-	- `app` steps use paths that exist in `apps.json`.
+	- `plugin` steps use slugs that exist in [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json).
+	- `app` steps use paths that exist in [apps.json](https://github.com/WordPress/blueprints/blob/trunk/apps.json).
 	- `github` steps use reachable `owner/repo` values.
 	- `note` steps with URLs open a useful screen.
 
@@ -140,7 +140,7 @@ Include:
 - Notes about external services, API keys, paid features, tracking, or privacy-sensitive behavior.
 - A short explanation of why each required step belongs in the sequence.
 
-Keep the pull request focused. A recipe-only submission should usually touch `blueprints/my-wordpress/recipes.json` and, if needed, the plugin or app files required by the recipe.
+Keep the pull request focused. A recipe-only submission should usually touch [blueprints/my-wordpress/recipes.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/recipes.json) and, if needed, the plugin or app files required by the recipe.
 
 ## Review Checklist
 
@@ -152,4 +152,4 @@ Reviewers should be able to answer yes to these questions:
 - Do plugin, app, and GitHub references resolve?
 - Are dependencies and external services disclosed?
 - Is the writing clear enough for someone who has not seen the pull request?
-- Is `recipes.json` valid and consistently formatted?
+- Is [recipes.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/recipes.json) valid and consistently formatted?

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -112,30 +112,26 @@ Keep recipes practical and specific:
 
 Before opening a pull request:
 
-1. Validate `recipes.json`:
-
-	```bash
-	python3 -m json.tool blueprints/my-wordpress/recipes.json >/dev/null
-	```
-
-2. Format it with the repository's Prettier settings if available:
+1. Format `recipes.json` with the repository's Prettier settings if available:
 
 	```bash
 	npx prettier --write blueprints/my-wordpress/recipes.json
 	```
 
-3. Check every referenced dependency:
+2. Check every referenced dependency:
 
 	- `plugin` steps use slugs that exist in `blueprints/my-wordpress/plugins.json`.
 	- `app` steps use paths that exist in `apps.json`.
 	- `github` steps use reachable `owner/repo` values.
 	- `note` steps with URLs open a useful screen.
 
-4. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
+3. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
+
+The pull request will run a GitHub Action that validates the My WordPress and app catalog JSON files.
 
 ## Open the Pull Request
 
-Submit a pull request against the `wordpress/blueprints` repository.
+[Open a pull request](https://github.com/WordPress/blueprints/compare) against the `wordpress/blueprints` repository.
 
 Include:
 

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -127,7 +127,7 @@ Before opening a pull request:
 
 3. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
 
-The pull request will run a GitHub Action that validates the My WordPress and app catalog JSON files.
+The pull request will run a GitHub Action that validates JSON syntax and checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -127,7 +127,7 @@ Before opening a pull request:
 
 3. Read the recipe as a user flow from top to bottom. The sequence should still make sense if optional steps are skipped.
 
-The pull request will run a GitHub Action that validates JSON syntax and checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema.
+The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -8,6 +8,8 @@ My WordPress uses the [My Apps](https://github.com/akirk/my-apps) plugin for its
 - **Plugin entry:** a single WordPress plugin listed in `blueprints/my-wordpress/plugins.json` for the curated app store.
 - **Permanent app:** a complete Playground Blueprint in `apps/*.json`, usually installing one or more plugins and opening a useful landing page after setup.
 
+Recipes are guided workflows rather than app-store entries. To contribute one, see [Contributing Recipes](./contributing-recipes.md).
+
 If you want to submit a full Blueprint to the public Blueprints gallery instead, follow the repository-wide [Contribution Guidelines](../../CONTRIBUTING.md).
 
 ## First: Test in My Apps
@@ -62,7 +64,12 @@ Make sure the plugin or app is ready for a fresh WordPress Playground site:
 - The first screen after installation gives users a clear next step.
 - The pasted My Apps test flow works before you create a pull request in this repository.
 
-For plugins that need build steps such as `composer install`, `npm install`, or `npm run build`, a `dist` branch can be the easiest target. During development, a Blueprint can use a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json), with `refType` set to `branch` and `ref` pointing at any GitHub branch you want to test. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`, so a Blueprint can point `ref` at a built branch such as `dist/main`. Use `targetFolderName` when the plugin folder name should stay stable.
+### Tips
+
+- For plugins with build steps such as `composer install`, `npm install`, or `npm run build`, test the built copy rather than the raw source.
+- A `dist` branch can be a good target for built files. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`.
+- During development, a Blueprint can use a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json), with `refType` set to `branch` and `ref` pointing at any GitHub branch you want to test.
+- Use `targetFolderName` when the plugin folder name should stay stable.
 
 If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
 
@@ -180,36 +187,6 @@ If the GitHub repository contains extra build files or the plugin folder name sh
 }
 ```
 
-## Option 3: Add It to a Recipe
-
-Recipes are guided workflows shown by My WordPress. If the plugin or app fits an existing workflow, add a step to `blueprints/my-wordpress/recipes.json`.
-
-For a plugin:
-
-```json
-{
-	"type": "plugin",
-	"slug": "example-plugin",
-	"title": "Install Example Plugin",
-	"description": "Explain why this belongs in the workflow.",
-	"optional": true
-}
-```
-
-For an app:
-
-```json
-{
-	"type": "app",
-	"path": "apps/example-app.json",
-	"title": "Install Example App",
-	"description": "Explain what this app unlocks for the workflow.",
-	"optional": true
-}
-```
-
-Only add a recipe entry when the plugin or app has a clear role in that recipe. Do not use recipes as a general catalog.
-
 ## Test the Submission
 
 Before opening a pull request:
@@ -217,16 +194,15 @@ Before opening a pull request:
 1. Validate every edited JSON file:
 
 	```bash
-	python -m json.tool blueprints/my-wordpress/plugins.json >/dev/null
-	python -m json.tool blueprints/my-wordpress/recipes.json >/dev/null
-	python -m json.tool apps/example-app.json >/dev/null
-	python -m json.tool apps.json >/dev/null
+	python3 -m json.tool blueprints/my-wordpress/plugins.json >/dev/null
+	python3 -m json.tool apps/example-app.json >/dev/null
+	python3 -m json.tool apps.json >/dev/null
 	```
 
 2. Format JSON with the repository's Prettier settings if available:
 
 	```bash
-	npx prettier --write blueprints/my-wordpress/plugins.json blueprints/my-wordpress/recipes.json apps/example-app.json apps.json
+	npx prettier --write blueprints/my-wordpress/plugins.json apps/example-app.json apps.json
 	```
 
 3. Try the app Blueprint in WordPress Playground. For a branch on GitHub, use a URL like:
@@ -258,7 +234,7 @@ Include:
 - Notes about external services, API keys, paid features, tracking, or privacy-sensitive behavior.
 - Confirmation that the code is GPL-compatible or already approved in the WordPress.org Plugin Directory.
 
-Keep the pull request focused. A plugin-only submission should usually touch `blueprints/my-wordpress/plugins.json` and, if appropriate, `blueprints/my-wordpress/recipes.json`. An app submission should usually add one file under `apps/`, update `apps.json`, and optionally update `recipes.json`.
+Keep the pull request focused. A plugin-only submission should usually touch `blueprints/my-wordpress/plugins.json`. An app submission should usually add one file under `apps/` and update `apps.json`.
 
 ## Review Checklist
 
@@ -270,7 +246,6 @@ Reviewers should be able to answer yes to these questions:
 - Is the landing page useful immediately after installation?
 - Are dependencies and external services disclosed?
 - Is the submitted app broader than a single plugin entry, or should it be simplified?
-- Does the recipe placement help users complete a real workflow?
 - Are JSON files valid and consistently formatted?
 
 If something is uncertain, open an issue or draft pull request first and describe the intended user flow.

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -55,12 +55,12 @@ If your Blueprint's title matches an existing app, My Apps can temporarily overr
 
 Make sure the plugin or app is ready for a fresh WordPress Playground site:
 
-- It installs a built version of the plugin or app and activates cleanly on a new site. Run required build steps before testing or submitting, such as `composer install`, `npm install`, or `npm run build`, so the installed copy already includes its runtime dependencies and compiled assets.
+- It installs and activates cleanly from a built copy, including runtime dependencies and compiled assets.
 - It does not require secrets, private API keys, or credentials to run its basic flow.
 - Any paid service, external account, tracking, or network dependency is clearly disclosed.
 - The code is GPL-compatible if it is submitted to this repository or distributed through WordPress.org.
 - The first screen after installation gives users a clear next step.
-- The pasted My Apps test flow works before you ask for permanent inclusion.
+- The pasted My Apps test flow works before you create a pull request in this repository.
 
 During development, it can be useful to install directly from a GitHub branch with a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json). Point `ref` at the branch you want to test, and use `targetFolderName` when the plugin folder name should stay stable:
 
@@ -79,7 +79,7 @@ During development, it can be useful to install directly from a GitHub branch wi
 }
 ```
 
-Use the branch workflow for testing and review, but make sure the referenced branch contains the built files needed for activation.
+For plugins that need build steps such as `composer install`, `npm install`, or `npm run build`, a `dist` branch can be the easiest target. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`. A Blueprint can then point `ref` at a built branch such as `dist/main`.
 
 If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
 
@@ -115,7 +115,7 @@ Prefer a WordPress.org slug for broadly distributed plugins. Use `github`, `bran
 
 ## Option 2: Submit an App
 
-Use this path when the My Apps pasted-Blueprint test works and the experience needs permanent inclusion in the curated app store. This is most useful for companion plugins, setup code, imported starter data, custom options, or a specific landing page.
+Use this path when the My Apps pasted-Blueprint test works and you want to create a pull request for permanent inclusion in the curated app store. This is most useful for companion plugins, setup code, imported starter data, custom options, or a specific landing page.
 
 Create a new Blueprint file in `apps/`, for example `apps/example-app.json`:
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -1,0 +1,273 @@
+# Submitting Plugins and Apps for My WordPress
+
+This guide explains how to test and propose a plugin or app for the My WordPress experience in this repository.
+
+My WordPress uses the [My Apps](https://github.com/akirk/my-apps) plugin for its launcher and app store. There are three related paths:
+
+- **Temporary app:** a complete WordPress Playground `blueprint.json` pasted into My Apps for local testing.
+- **Plugin entry:** a single WordPress plugin listed in `blueprints/my-wordpress/plugins.json` for the curated app store.
+- **Permanent app:** a complete Playground Blueprint in `apps/*.json`, usually installing one or more plugins and opening a useful landing page after setup.
+
+If you want to submit a full Blueprint to the public Blueprints gallery instead, follow the repository-wide [Contribution Guidelines](../../CONTRIBUTING.md).
+
+## First: Test in My Apps
+
+Before opening a pull request, test the app through the My Apps flow for [temporarily adding an app from a Blueprint](https://github.com/akirk/my-apps#temporarily-adding-an-app-from-a-blueprint).
+
+Create a complete WordPress Playground `blueprint.json` with `meta.title`, `meta.description`, and `meta.author`. My Apps reads those fields to create the app-store entry.
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "My Custom App",
+		"description": "Installs my custom WordPress app.",
+		"author": "Your Name"
+	},
+	"landingPage": "/wp-admin/",
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}
+```
+
+To install it temporarily:
+
+1. Open My Apps at `/my-apps/`.
+2. Choose **Add**.
+3. Paste the complete Blueprint anywhere in the App Store. On mobile, focus the Search field and paste it there.
+4. Install the temporary app from the app-store entry My Apps creates.
+
+If your Blueprint's title matches an existing app, My Apps can temporarily override that app with the pasted Blueprint. Custom and modified entries are stored only in the current browser and can be removed or reverted from their badge in the App Store.
+
+## Before You Submit
+
+Make sure the plugin or app is ready for a fresh WordPress Playground site:
+
+- It installs without manual file uploads.
+- It activates cleanly on a new site.
+- It does not require secrets, private API keys, or credentials to run its basic flow.
+- Any paid service, external account, tracking, or network dependency is clearly disclosed.
+- The code is GPL-compatible if it is submitted to this repository or distributed through WordPress.org.
+- The first screen after installation gives users a clear next step.
+- The pasted My Apps test flow works before you ask for permanent inclusion.
+
+If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
+
+## Option 1: Submit a Plugin Entry
+
+Use this path when one existing plugin is enough and no custom setup Blueprint is needed. If the plugin itself should create a launcher icon after installation, it can register with My Apps by filtering `my_apps_plugins` in the plugin code.
+
+Add an object to `blueprints/my-wordpress/plugins.json` using the plugin slug as the key:
+
+```json
+{
+	"example-plugin": {
+		"title": "Example Plugin",
+		"author": "Example Author",
+		"note": "A short, user-facing explanation of what this adds to My WordPress.",
+		"categories": ["Productivity"],
+		"landing_page": "/wp-admin/admin.php?page=example-plugin"
+	}
+}
+```
+
+Common fields:
+
+- `note`: required in practice; keep it short and explain the user benefit.
+- `categories`: one or more labels used for browsing.
+- `landing_page`: optional, but recommended when the plugin has a settings page, dashboard, or frontend route.
+- `title` and `author`: recommended when the display name is not obvious from the slug.
+- `github`: optional GitHub repository in `owner/repo` form when the plugin should be fetched from GitHub.
+- `branch`: optional branch name when the installable build lives outside the default branch, for example `dist/main`.
+- `url`: optional direct ZIP URL, commonly a GitHub release asset.
+
+Prefer a WordPress.org slug for broadly distributed plugins. Use `github`, `branch`, or `url` only when the plugin is not in the Plugin Directory or needs a specific build.
+
+## Option 2: Submit an App
+
+Use this path when the My Apps pasted-Blueprint test works and the experience needs permanent inclusion in the curated app store. This is most useful for companion plugins, setup code, imported starter data, custom options, or a specific landing page.
+
+Create a new Blueprint file in `apps/`, for example `apps/example-app.json`:
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"meta": {
+		"title": "Example App",
+		"description": "A short description of what the app lets users do.",
+		"author": "Example Author",
+		"categories": ["Apps", "Productivity"]
+	},
+	"landingPage": "/wp-admin/admin.php?page=example-app",
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "example-plugin"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}
+```
+
+Then register the app in `apps.json`:
+
+```json
+{
+	"apps/example-app.json": {
+		"title": "Example App",
+		"description": "A short description of what the app lets users do.",
+		"author": "Example Author",
+		"categories": ["Apps", "Productivity"]
+	}
+}
+```
+
+App Blueprints can use normal Playground steps, including `installPlugin`, `setSiteOptions`, `runPHP`, `importWxr`, and file operations. Keep setup steps idempotent where possible so the app does not damage existing content if installed more than once.
+
+The `meta.title`, `meta.description`, and `meta.author` fields should match the temporary Blueprint you tested in My Apps. If you intentionally replace or update an existing app, use the same title during temporary testing so reviewers can verify the override behavior.
+
+For plugin installs, use one of these resource patterns:
+
+```json
+{
+	"resource": "wordpress.org/plugins",
+	"slug": "friends"
+}
+```
+
+```json
+{
+	"resource": "url",
+	"url": "https://github.com/example/example-plugin/releases/latest/download/example-plugin.zip"
+}
+```
+
+```json
+{
+	"resource": "git:directory",
+	"url": "https://github.com/example/example-plugin",
+	"ref": "main",
+	"refType": "branch"
+}
+```
+
+If the GitHub repository contains extra build files or the plugin folder name should be stable, set `targetFolderName` in the install options:
+
+```json
+{
+	"options": {
+		"activate": true,
+		"targetFolderName": "example-plugin"
+	}
+}
+```
+
+## Option 3: Add It to a Recipe
+
+Recipes are guided workflows shown by My WordPress. If the plugin or app fits an existing workflow, add a step to `blueprints/my-wordpress/recipes.json`.
+
+For a plugin:
+
+```json
+{
+	"type": "plugin",
+	"slug": "example-plugin",
+	"title": "Install Example Plugin",
+	"description": "Explain why this belongs in the workflow.",
+	"optional": true
+}
+```
+
+For an app:
+
+```json
+{
+	"type": "app",
+	"path": "apps/example-app.json",
+	"title": "Install Example App",
+	"description": "Explain what this app unlocks for the workflow.",
+	"optional": true
+}
+```
+
+Only add a recipe entry when the plugin or app has a clear role in that recipe. Do not use recipes as a general catalog.
+
+## Test the Submission
+
+Before opening a pull request:
+
+1. Validate every edited JSON file:
+
+	```bash
+	python -m json.tool blueprints/my-wordpress/plugins.json >/dev/null
+	python -m json.tool blueprints/my-wordpress/recipes.json >/dev/null
+	python -m json.tool apps/example-app.json >/dev/null
+	python -m json.tool apps.json >/dev/null
+	```
+
+2. Format JSON with the repository's Prettier settings if available:
+
+	```bash
+	npx prettier --write blueprints/my-wordpress/plugins.json blueprints/my-wordpress/recipes.json apps/example-app.json apps.json
+	```
+
+3. Try the app Blueprint in WordPress Playground. For a branch on GitHub, use a URL like:
+
+	```text
+	https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/YOUR-BRANCH/apps/example-app.json
+	```
+
+4. Confirm the install flow:
+
+	- Pasting the complete Blueprint into My Apps creates the expected temporary app-store entry.
+	- The plugin or app installs without errors.
+	- The expected plugins are active.
+	- `landingPage` opens a useful screen.
+	- Any optional external service requirement is visible to the user.
+	- The uninstall/deactivate path does not leave the site broken.
+
+## Open the Pull Request
+
+Submit a pull request against the `wordpress/blueprints` repository.
+
+Include:
+
+- The plugin slug, GitHub repository, or ZIP URL being installed.
+- A short explanation of why it belongs in My WordPress.
+- Screenshots or a short screen recording of the install result.
+- The complete Blueprint used for the My Apps paste test, or a link to it.
+- A Playground test URL for permanent app Blueprints.
+- Notes about external services, API keys, paid features, tracking, or privacy-sensitive behavior.
+- Confirmation that the code is GPL-compatible or already approved in the WordPress.org Plugin Directory.
+
+Keep the pull request focused. A plugin-only submission should usually touch `blueprints/my-wordpress/plugins.json` and, if appropriate, `blueprints/my-wordpress/recipes.json`. An app submission should usually add one file under `apps/`, update `apps.json`, and optionally update `recipes.json`.
+
+## Review Checklist
+
+Reviewers should be able to answer yes to these questions:
+
+- Is the value clear from the title, description, and note?
+- Does the temporary My Apps paste flow create the expected app-store entry?
+- Does the install work in a clean Playground instance?
+- Is the landing page useful immediately after installation?
+- Are dependencies and external services disclosed?
+- Is the submitted app broader than a single plugin entry, or should it be simplified?
+- Does the recipe placement help users complete a real workflow?
+- Are JSON files valid and consistently formatted?
+
+If something is uncertain, open an issue or draft pull request first and describe the intended user flow.

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -69,7 +69,7 @@ Make sure the plugin or app is ready for a fresh WordPress Playground site:
 - For plugins with build steps such as `composer install`, `npm install`, or `npm run build`, test the built copy rather than the raw source.
 - A `dist` branch can be a good target for built files. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`.
 - During development, a Blueprint can use a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json), with `refType` set to `branch` and `ref` pointing at any GitHub branch you want to test.
-- Use `targetFolderName` when the plugin folder name should stay stable.
+- We recommend setting `targetFolderName` for `git:directory` installs so updates from different branches replace the same plugin folder instead of creating multiple copies of the same plugin.
 
 If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
 
@@ -191,27 +191,19 @@ If the GitHub repository contains extra build files or the plugin folder name sh
 
 Before opening a pull request:
 
-1. Validate every edited JSON file:
-
-	```bash
-	python3 -m json.tool blueprints/my-wordpress/plugins.json >/dev/null
-	python3 -m json.tool apps/example-app.json >/dev/null
-	python3 -m json.tool apps.json >/dev/null
-	```
-
-2. Format JSON with the repository's Prettier settings if available:
+1. Format JSON with the repository's Prettier settings if available:
 
 	```bash
 	npx prettier --write blueprints/my-wordpress/plugins.json apps/example-app.json apps.json
 	```
 
-3. Try the app Blueprint in WordPress Playground. For a branch on GitHub, use a URL like:
+2. Try the app Blueprint in WordPress Playground. For a branch on GitHub, use a URL like:
 
 	```text
 	https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/YOUR-BRANCH/apps/example-app.json
 	```
 
-4. Confirm the install flow:
+3. Confirm the install flow:
 
 	- Pasting the complete Blueprint into My Apps creates the expected temporary app-store entry.
 	- The plugin or app installs without errors.
@@ -220,9 +212,11 @@ Before opening a pull request:
 	- Any optional external service requirement is visible to the user.
 	- The uninstall/deactivate path does not leave the site broken.
 
+The pull request will run a GitHub Action that validates the My WordPress and app catalog JSON files.
+
 ## Open the Pull Request
 
-Submit a pull request against the `wordpress/blueprints` repository.
+[Open a pull request](https://github.com/WordPress/blueprints/compare) against the `wordpress/blueprints` repository.
 
 Include:
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -212,7 +212,7 @@ Before opening a pull request:
 	- Any optional external service requirement is visible to the user.
 	- The uninstall/deactivate path does not leave the site broken.
 
-The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas.
+The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas. You can run the same check locally with `npm run validate:my-wordpress-json`.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -16,6 +16,8 @@ Before opening a pull request, test the app through the My Apps flow for [tempor
 
 Create a complete WordPress Playground `blueprint.json` with `meta.title`, `meta.description`, and `meta.author`. My Apps reads those fields to create the app-store entry.
 
+If you do not want to write the Blueprint by hand, use the [WordPress Playground Step Library](https://akirk.github.io/playground-step-library/) to build it interactively. The Step Library can launch the Blueprint in Playground and copy the generated Blueprint JSON to your clipboard, ready to paste into My Apps.
+
 ```json
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -5,7 +5,7 @@ This guide explains how to test and propose a plugin or app for the My WordPress
 My WordPress uses the [My Apps](https://github.com/akirk/my-apps) plugin for its launcher and app store. There are three related paths:
 
 - **Temporary app:** a complete WordPress Playground `blueprint.json` pasted into My Apps for local testing.
-- **Plugin entry:** a single WordPress plugin listed in `blueprints/my-wordpress/plugins.json` for the curated app store.
+- **Plugin entry:** a single WordPress plugin listed in [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json) for the curated app store.
 - **Permanent app:** a complete Playground Blueprint in `apps/*.json`, usually installing one or more plugins and opening a useful landing page after setup.
 
 Recipes are guided workflows rather than app-store entries. To contribute one, see [Contributing Recipes](./contributing-recipes.md).
@@ -77,7 +77,7 @@ If the plugin should be installed from the WordPress.org Plugin Directory, submi
 
 Use this path when one existing plugin is enough and no custom setup Blueprint is needed. If the plugin itself should create a launcher icon after installation, it can register with My Apps by filtering `my_apps_plugins` in the plugin code.
 
-Add an object to `blueprints/my-wordpress/plugins.json` using the plugin slug as the key:
+Add an object to [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json) using the plugin slug as the key:
 
 ```json
 {
@@ -134,7 +134,7 @@ Create a new Blueprint file in `apps/`, for example `apps/example-app.json`:
 }
 ```
 
-Then register the app in `apps.json`:
+Then register the app in [apps.json](https://github.com/WordPress/blueprints/blob/trunk/apps.json):
 
 ```json
 {
@@ -228,7 +228,7 @@ Include:
 - Notes about external services, API keys, paid features, tracking, or privacy-sensitive behavior.
 - Confirmation that the code is GPL-compatible or already approved in the WordPress.org Plugin Directory.
 
-Keep the pull request focused. A plugin-only submission should usually touch `blueprints/my-wordpress/plugins.json`. An app submission should usually add one file under `apps/` and update `apps.json`.
+Keep the pull request focused. A plugin-only submission should usually touch [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json). An app submission should usually add one file under `apps/` and update [apps.json](https://github.com/WordPress/blueprints/blob/trunk/apps.json).
 
 ## Review Checklist
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -212,7 +212,7 @@ Before opening a pull request:
 	- Any optional external service requirement is visible to the user.
 	- The uninstall/deactivate path does not leave the site broken.
 
-The pull request will run a GitHub Action that validates the My WordPress and app catalog JSON files.
+The pull request will run a GitHub Action that validates JSON syntax and checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -55,13 +55,31 @@ If your Blueprint's title matches an existing app, My Apps can temporarily overr
 
 Make sure the plugin or app is ready for a fresh WordPress Playground site:
 
-- It installs without manual file uploads.
-- It activates cleanly on a new site.
+- It installs a built version of the plugin or app and activates cleanly on a new site. Run required build steps before testing or submitting, such as `composer install`, `npm install`, or `npm run build`, so the installed copy already includes its runtime dependencies and compiled assets.
 - It does not require secrets, private API keys, or credentials to run its basic flow.
 - Any paid service, external account, tracking, or network dependency is clearly disclosed.
 - The code is GPL-compatible if it is submitted to this repository or distributed through WordPress.org.
 - The first screen after installation gives users a clear next step.
 - The pasted My Apps test flow works before you ask for permanent inclusion.
+
+During development, it can be useful to install directly from a GitHub branch with a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json). Point `ref` at the branch you want to test, and use `targetFolderName` when the plugin folder name should stay stable:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "git:directory",
+		"url": "https://github.com/akirk/my-apps",
+		"ref": "main",
+		"refType": "branch"
+	},
+	"options": {
+		"targetFolderName": "my-apps"
+	}
+}
+```
+
+Use the branch workflow for testing and review, but make sure the referenced branch contains the built files needed for activation.
 
 If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -212,7 +212,7 @@ Before opening a pull request:
 	- Any optional external service requirement is visible to the user.
 	- The uninstall/deactivate path does not leave the site broken.
 
-The pull request will run a GitHub Action that validates JSON syntax and checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema.
+The pull request will run a GitHub Action that validates JSON syntax, checks app and My WordPress Blueprint files against the WordPress Playground Blueprint schema, and checks catalog files against the My Apps schemas.
 
 ## Open the Pull Request
 

--- a/blueprints/my-wordpress/submitting-plugins-and-apps.md
+++ b/blueprints/my-wordpress/submitting-plugins-and-apps.md
@@ -62,24 +62,7 @@ Make sure the plugin or app is ready for a fresh WordPress Playground site:
 - The first screen after installation gives users a clear next step.
 - The pasted My Apps test flow works before you create a pull request in this repository.
 
-During development, it can be useful to install directly from a GitHub branch with a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json). Point `ref` at the branch you want to test, and use `targetFolderName` when the plugin folder name should stay stable:
-
-```json
-{
-	"step": "installPlugin",
-	"pluginData": {
-		"resource": "git:directory",
-		"url": "https://github.com/akirk/my-apps",
-		"ref": "main",
-		"refType": "branch"
-	},
-	"options": {
-		"targetFolderName": "my-apps"
-	}
-}
-```
-
-For plugins that need build steps such as `composer install`, `npm install`, or `npm run build`, a `dist` branch can be the easiest target. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`. A Blueprint can then point `ref` at a built branch such as `dist/main`.
+For plugins that need build steps such as `composer install`, `npm install`, or `npm run build`, a `dist` branch can be the easiest target. During development, a Blueprint can use a `git:directory` resource, as in the [My Apps Blueprint](https://github.com/akirk/my-apps/blob/main/blueprint.json), with `refType` set to `branch` and `ref` pointing at any GitHub branch you want to test. For example, [Personal CRM's build-dist workflow](https://github.com/akirk/personal-crm/blob/main/.github/workflows/build-dist.yml) installs Composer dependencies, commits `vendor/`, and pushes the result to `dist/<branch>`, so a Blueprint can point `ref` at a built branch such as `dist/main`. Use `targetFolderName` when the plugin folder name should stay stable.
 
 If the plugin should be installed from the WordPress.org Plugin Directory, submit it there first. WordPress.org expects a complete plugin ZIP, a valid WordPress.org account, a checked email address, and compliance with the Plugin Directory guidelines. Once the plugin has an approved directory slug, My WordPress can install it with the `wordpress.org/plugins` resource.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "blueprints-screenshots",
       "devDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "playwright": "^1.48.0",
         "tsx": "^4.19.0"
       }
@@ -452,6 +454,41 @@
         "node": ">=18"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -494,6 +531,30 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -521,6 +582,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.56.1",
@@ -552,6 +620,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "shots": "tsx scripts/screenshot-blueprints.ts"
+    "shots": "tsx scripts/screenshot-blueprints.ts",
+    "validate:my-wordpress-json": "node scripts/validate-my-wordpress-json.js"
   },
   "devDependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "playwright": "^1.48.0",
     "tsx": "^4.19.0"
   }

--- a/scripts/validate-my-wordpress-json.js
+++ b/scripts/validate-my-wordpress-json.js
@@ -11,6 +11,10 @@ const BLUEPRINT_SCHEMA_URL =
 const MY_APPS_SCHEMA_BASE_URL =
 	process.env.MY_APPS_SCHEMA_BASE_URL ||
 	'https://raw.githubusercontent.com/akirk/my-apps/main/schemas';
+const SCHEMA_FETCH_TIMEOUT_MS = Number.parseInt(
+	process.env.SCHEMA_FETCH_TIMEOUT_MS || '15000',
+	10
+);
 
 function listJsonFiles(dir, recursive = false) {
 	if (!fs.existsSync(dir)) {
@@ -47,10 +51,26 @@ function ajvPath(instancePath) {
 }
 
 async function fetchJson(url) {
-	const response = await fetch(url);
-	if (!response.ok) {
-		throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+	let response;
+	try {
+		response = await fetch(url, {
+			signal: AbortSignal.timeout(SCHEMA_FETCH_TIMEOUT_MS),
+		});
+	} catch (error) {
+		if (error.name === 'TimeoutError' || error.name === 'AbortError') {
+			throw new Error(
+				`Timed out fetching ${url} after ${SCHEMA_FETCH_TIMEOUT_MS}ms`
+			);
+		}
+		throw error;
 	}
+
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch ${url}: ${response.status} ${response.statusText}`
+		);
+	}
+
 	return response.json();
 }
 
@@ -120,14 +140,24 @@ function validateJsonSyntax() {
 		...listJsonFiles('blueprints/my-wordpress', true),
 	].sort();
 
+	let failed = false;
 	for (const filePath of jsonFiles) {
-		readJson(filePath);
-		console.log(`Valid JSON: ${filePath}`);
+		try {
+			readJson(filePath);
+			console.log(`Valid JSON: ${filePath}`);
+		} catch (error) {
+			failed = true;
+			reportError(filePath, `Invalid JSON: ${error.message}`);
+		}
 	}
+
+	return !failed;
 }
 
 async function main() {
-	validateJsonSyntax();
+	if (!validateJsonSyntax()) {
+		process.exit(1);
+	}
 
 	const blueprintsValid = await validateBlueprints();
 	const catalogsValid = await validateCatalogs();

--- a/scripts/validate-my-wordpress-json.js
+++ b/scripts/validate-my-wordpress-json.js
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Ajv from 'ajv';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const BLUEPRINT_SCHEMA_URL =
+	process.env.BLUEPRINT_SCHEMA_URL ||
+	'https://raw.githubusercontent.com/WordPress/wordpress-playground/trunk/packages/playground/blueprints/public/blueprint-schema.json';
+const MY_APPS_SCHEMA_BASE_URL =
+	process.env.MY_APPS_SCHEMA_BASE_URL ||
+	'https://raw.githubusercontent.com/akirk/my-apps/main/schemas';
+
+function listJsonFiles(dir, recursive = false) {
+	if (!fs.existsSync(dir)) {
+		return [];
+	}
+
+	const files = [];
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const entryPath = path.join(dir, entry.name);
+		if (entry.isDirectory() && recursive) {
+			files.push(...listJsonFiles(entryPath, true));
+		} else if (entry.isFile() && entry.name.endsWith('.json')) {
+			files.push(entryPath);
+		}
+	}
+	return files;
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function reportError(filePath, message) {
+	if (process.env.GITHUB_ACTIONS) {
+		console.log(`::error file=${filePath}::${message}`);
+		return;
+	}
+
+	console.error(`${filePath}: ${message}`);
+}
+
+function ajvPath(instancePath) {
+	return instancePath ? instancePath.slice(1).replaceAll('/', '.') : '<root>';
+}
+
+async function fetchJson(url) {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+	}
+	return response.json();
+}
+
+async function validateBlueprints() {
+	const blueprintSchema = await fetchJson(BLUEPRINT_SCHEMA_URL);
+	const blueprintAjv = new Ajv({
+		allErrors: true,
+		strict: false,
+		validateSchema: false,
+	});
+	const validateBlueprint = blueprintAjv.compile(blueprintSchema);
+	const blueprintFiles = [
+		'blueprints/my-wordpress/blueprint.json',
+		...listJsonFiles('apps'),
+	].sort();
+
+	let failed = false;
+	for (const filePath of blueprintFiles) {
+		const valid = validateBlueprint(readJson(filePath));
+		if (valid) {
+			console.log(`Valid Blueprint schema: ${filePath}`);
+			continue;
+		}
+
+		failed = true;
+		for (const error of validateBlueprint.errors || []) {
+			reportError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
+		}
+	}
+
+	return !failed;
+}
+
+async function validateCatalogs() {
+	const catalogAjv = new Ajv2020({ allErrors: true, strict: false });
+	addFormats(catalogAjv);
+
+	const catalogChecks = {
+		'apps.json': `${MY_APPS_SCHEMA_BASE_URL}/apps.schema.json`,
+		'blueprints/my-wordpress/plugins.json': `${MY_APPS_SCHEMA_BASE_URL}/plugins.schema.json`,
+		'blueprints/my-wordpress/recipes.json': `${MY_APPS_SCHEMA_BASE_URL}/recipes.schema.json`,
+	};
+
+	let failed = false;
+	for (const [filePath, schemaUrl] of Object.entries(catalogChecks)) {
+		const schema = await fetchJson(schemaUrl);
+		const validateCatalog = catalogAjv.compile(schema);
+		const valid = validateCatalog(readJson(filePath));
+		if (valid) {
+			console.log(`Valid My Apps catalog schema: ${filePath}`);
+			continue;
+		}
+
+		failed = true;
+		for (const error of validateCatalog.errors || []) {
+			reportError(filePath, `${ajvPath(error.instancePath)}: ${error.message}`);
+		}
+	}
+
+	return !failed;
+}
+
+function validateJsonSyntax() {
+	const jsonFiles = [
+		'apps.json',
+		...listJsonFiles('apps'),
+		...listJsonFiles('blueprints/my-wordpress', true),
+	].sort();
+
+	for (const filePath of jsonFiles) {
+		readJson(filePath);
+		console.log(`Valid JSON: ${filePath}`);
+	}
+}
+
+async function main() {
+	validateJsonSyntax();
+
+	const blueprintsValid = await validateBlueprints();
+	const catalogsValid = await validateCatalogs();
+
+	if (!blueprintsValid || !catalogsValid) {
+		process.exit(1);
+	}
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add My WordPress contributor documentation for submitting plugins, apps, and recipes
  - https://github.com/WordPress/blueprints/blob/my-wordpress-add-submission-instructions/blueprints/my-wordpress/README.md
  -  https://github.com/WordPress/blueprints/blob/my-wordpress-add-submission-instructions/blueprints/my-wordpress/contributing-recipes.md
  - https://github.com/WordPress/blueprints/blob/my-wordpress-add-submission-instructions/blueprints/my-wordpress/submitting-plugins-and-apps.md
- Document the My Apps pasted-Blueprint test flow before creating a permanent catalog PR
- Add a reusable Node validator and GitHub Action for My WordPress JSON, Blueprint schema, and My Apps catalog schema checks → make sure users don't submit wrong jsons

I would link the README.md from here:
<img width="834" height="661" alt="Screenshot 2026-05-08 at 12 11 08" src="https://github.com/user-attachments/assets/e05bf190-e6ba-44bc-8a07-26f3d01e874d" />


## Testing
- Ran `npm run validate:my-wordpress-json` locally