### PR TITLE
[codex] Add POP to My WordPress apps

### DIFF
--- a/blueprints/my-wordpress/plugins.json
+++ b/blueprints/my-wordpress/plugins.json
@@ -115,5 +115,12 @@
 		"note": "Reimagines /wp-admin as a desktop OS — admin screens open as draggable, resizable windows on a wallpaper, with a dock built from the admin menu. Per-user opt-in, fully reverts on deactivation.",
 		"categories": ["Productivity"],
 		"landing_page": "/desktop-mode/"
+	},
+	"woopop-electronic-invoice-free": {
+		"title": "POP",
+		"author": "POP",
+		"note": "Generate XML and PDF e-invoices for WooCommerce and other WordPress payment flows. Requires a POP account; the free plan includes 20 API credits per month.",
+		"categories": ["Utility"],
+		"landing_page": "/wp-admin/admin.php?page=wc_el_inv-options-page&tab=wizard&wizard=init"
 	}
 }


### PR DESCRIPTION
## Summary
- add the WordPress.org POP plugin slug to the My WordPress curated plugin catalog
- point installs to POP's setup wizard so users land on an actionable first-run screen
- disclose that POP requires a POP account and that the free plan includes 20 API credits per month

## Why
POP is already approved in the WordPress.org Plugin Directory and gives My WordPress users a focused electronic invoicing option for WooCommerce and broader WordPress payment flows.

## Validation
- ran `npm run validate:my-wordpress-json`

## Notes
- plugin slug: `woopop-electronic-invoice-free`
- plugin page: https://wordpress.org/plugins/woopop-electronic-invoice-free/
- POP account required for the core flow; paid plans unlock additional compliance and delivery features
- submission follows `blueprints/my-wordpress/submitting-plugins-and-apps.md` as a plugin entry, not a full app blueprint
