### PR TITLE
Migrate BrewCommerce Blueprint to current schema

### DIFF
--- a/blueprints/brewcommerce/blueprint.json
+++ b/blueprints/brewcommerce/blueprint.json
@@ -14,12 +14,11 @@
 	"steps": [
 		{
 			"step": "login",
-			"username": "admin",
-			"password": "password"
+			"username": "admin"
 		},
 		{
 			"step": "installTheme",
-			"themeZipFile": {
+			"themeData": {
 				"resource": "bundled",
 				"path": "./theme.zip"
 			},


### PR DESCRIPTION
## What changed

- Replaced the BrewCommerce Blueprint's deprecated `themeZipFile` field with `themeData`.
- Removed the deprecated `password` field from the `login` step.

## Why

The PR Blueprint validation workflow fetches the latest Playground v1 schema, where `installTheme` requires `themeData`. Keeping `themeZipFile` causes the whole BrewCommerce Blueprint to fail validation whenever any file in that blueprint directory changes.

## Validation

- `CHANGED_FILES='blueprints/brewcommerce/blueprint.json' GITHUB_BRANCH='adamziel/weird-ci-failure' npm run validate:pr-blueprints`
