### PR TITLE
Restore app catalog icons

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -6,7 +6,8 @@
     "categories": [
       "Apps",
       "AI"
-    ]
+    ],
+    "icon": "dashicons-format-chat"
   },
   "blueprints/apiary-press/blueprint.json": {
     "title": "Apiary Press",
@@ -14,8 +15,9 @@
     "author": "Francesco Bigiarini",
     "categories": [
       "Apps",
-      "WordPress"
-    ]
+      "Productivity"
+    ],
+    "icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/apiary-press/icon.svg"
   },
   "blueprints/chat-to-blog/blueprint.json": {
     "title": "Chat to Blog",
@@ -24,7 +26,8 @@
     "categories": [
       "Apps",
       "Media"
-    ]
+    ],
+    "icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/chat-to-blog/icon.svg"
   },
   "blueprints/post-collection/blueprint.json": {
     "title": "Collect Posts from the Web",
@@ -33,7 +36,8 @@
     "categories": [
       "Apps",
       "Productivity"
-    ]
+    ],
+    "icon": "dashicons-book"
   },
   "blueprints/cookbook/blueprint.json": {
     "title": "Cookbook",
@@ -51,7 +55,8 @@
     "categories": [
       "Apps",
       "Productivity"
-    ]
+    ],
+    "icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/memex/icon.svg"
   },
   "blueprints/personal-crm/blueprint.json": {
     "title": "Personal CRM",
@@ -60,7 +65,8 @@
     "categories": [
       "Apps",
       "Productivity"
-    ]
+    ],
+    "icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/personal-crm/icon.svg"
   },
   "blueprints/rss-reader/blueprint.json": {
     "title": "RSS Reader",
@@ -69,7 +75,8 @@
     "categories": [
       "Apps",
       "Social"
-    ]
+    ],
+    "icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/rss-reader/icon.png"
   },
   "blueprints/wordcamp-companion/blueprint.json": {
     "title": "WordCamp Companion",
@@ -87,7 +94,8 @@
     "categories": [
       "Apps",
       "Education"
-    ]
+    ],
+    "icon": "dashicons-welcome-learn-more"
   },
   "blueprints/wordopedia/blueprint.json": {
     "title": "Wordopedia",

--- a/blueprints/ai-assistant/app-meta.json
+++ b/blueprints/ai-assistant/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "dashicons-format-chat"
+}

--- a/blueprints/apiary-press/app-meta.json
+++ b/blueprints/apiary-press/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/apiary-press/icon.svg"
+}

--- a/blueprints/apiary-press/blueprint.json
+++ b/blueprints/apiary-press/blueprint.json
@@ -4,7 +4,7 @@
 		"title": "Apiary Press",
 		"description": "Track beehives and record hive visits.",
 		"author": "Francesco Bigiarini",
-		"categories": ["Apps", "WordPress"]
+		"categories": ["Apps", "Productivity"]
 	},
 	"landingPage": "/apiary-press/",
 	"steps": [

--- a/blueprints/chat-to-blog/app-meta.json
+++ b/blueprints/chat-to-blog/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/chat-to-blog/icon.svg"
+}

--- a/blueprints/memex/app-meta.json
+++ b/blueprints/memex/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/memex/icon.svg"
+}

--- a/blueprints/personal-crm/app-meta.json
+++ b/blueprints/personal-crm/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/personal-crm/icon.svg"
+}

--- a/blueprints/post-collection/app-meta.json
+++ b/blueprints/post-collection/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "dashicons-book"
+}

--- a/blueprints/rss-reader/app-meta.json
+++ b/blueprints/rss-reader/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/rss-reader/icon.png"
+}

--- a/blueprints/wordpress-courses/app-meta.json
+++ b/blueprints/wordpress-courses/app-meta.json
@@ -1,0 +1,3 @@
+{
+	"icon": "dashicons-welcome-learn-more"
+}

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -97,6 +97,15 @@ def is_app_blueprint(meta):
     return 'Apps' in (meta.get('categories') or [])
 
 
+def load_app_meta(blueprint_path):
+    app_meta_path = os.path.join(os.path.dirname(blueprint_path), 'app-meta.json')
+    if not os.path.exists(app_meta_path):
+        return {}
+
+    with open(app_meta_path, 'r') as f:
+        return json.load(f)
+
+
 def build_apps_index():
     index = {}
     for root, dirs, files in os.walk('blueprints'):
@@ -107,7 +116,9 @@ def build_apps_index():
                     data = json.load(f)
                     meta = data.get('meta', {})
                     if is_app_blueprint(meta):
-                        index[path] = dict(meta)
+                        app_meta = dict(meta)
+                        app_meta.update(load_app_meta(path))
+                        index[path] = app_meta
     index = dict(sorted(index.items(), key=lambda item: item[1].get('title', '')))
     with open('apps.json', 'w') as f:
         json.dump(index, f, indent=2)


### PR DESCRIPTION
## Summary
- add per-blueprint app-meta.json sidecars for app catalog-only icon metadata
- merge app-meta.json into apps.json during reindexing
- restore the app icons removed by the latest reindex job without adding unsupported fields to blueprint.json

## Testing
- npm run validate:my-wordpress-json
- env GITHUB_BRANCH=trunk CHANGED_FILES=$'blueprints/ai-assistant/app-meta.json\nblueprints/apiary-press/app-meta.json\nblueprints/chat-to-blog/app-meta.json\nblueprints/memex/app-meta.json\nblueprints/personal-crm/app-meta.json\nblueprints/post-collection/app-meta.json\nblueprints/rss-reader/app-meta.json\nblueprints/wordpress-courses/app-meta.json' npm run validate:pr-blueprints
- node JSON.parse check for all app-meta.json files