### PR TITLE
Remove stale rewrite flush from theme demo blueprint

### DIFF
--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -14,8 +14,8 @@
 		},
 		{
 			"step": "writeFile",
-			"path": "/wordpress/wp-content/mu-plugins/rewrite.php",
-			"data": "<?php /* Use pretty permalinks */ add_action( 'after_setup_theme', function() { global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules(); } );"
+			"path": "/wordpress/wp-content/mu-plugins/demo-body-class.php",
+			"data": "<?php add_filter( 'body_class', function ( $classes ) { $classes[] = 'playground-demo'; return $classes; } );"
 		},
 		{
 			"step": "updateUserMeta",
@@ -29,18 +29,22 @@
 		{
 			"step": "installTheme",
 			"themeData": {
-				"resource": "url",
-				"url": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip"
+				"resource": "git:directory",
+				"url": "https://github.com/richtabor/kanso.git",
+				"ref": "main",
+				"refType": "branch",
+				"path": "/"
 			},
 			"options": {
-				"activate": true
+				"activate": true,
+				"targetFolderName": "kanso-main"
 			}
 		},
 		{
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://github.com/WordPress/blueprints/blob/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
+				"url": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
 			}
 		}
 	],


### PR DESCRIPTION
## Summary

- Remove the stale `rewrite.php` mu-plugin example that calls `flush_rules()`.
- Use a small `writeFile` example that adds a demo body class instead.
- Switch the Kanso theme source to `git:directory` so PR Blueprint validation accepts the external source.
- Point the WXR import to this branch raw URL for PR validation.

## Dependency

This supports WordPress/wordpress-playground#3806. Once this PR lands, that Playground docs PR can keep the Run Blueprint link pointing to Blueprints `trunk`.

cc @bgrgicak based on the review direction in WordPress/wordpress-playground#3806.

## Testing

- `git diff --check`
- `GITHUB_BRANCH='remove-theme-demo-flush-rules' CHANGED_FILES='blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json' npm run validate:pr-blueprints`