### PR TITLE
[Blueprints] Validate current-branch and trunk URLs

### DIFF
--- a/.github/workflows/has-valid-blueprint-json.yml
+++ b/.github/workflows/has-valid-blueprint-json.yml
@@ -38,5 +38,8 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Test Blueprint URL handling
+              run: npm run test:pr-blueprint-urls
+
             - name: Validate Blueprint JSON
               run: npm run validate:pr-blueprints

--- a/.github/workflows/has-valid-blueprint-json.yml
+++ b/.github/workflows/has-valid-blueprint-json.yml
@@ -8,7 +8,8 @@ jobs:
         runs-on: ubuntu-latest
 
         env:
-            GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+            PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+            PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
             GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
             BLUEPRINT_SCHEMA_URL: "https://raw.githubusercontent.com/WordPress/wordpress-playground/trunk/packages/playground/blueprints/public/blueprint-schema.json"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,14 @@ Submit [a Pull Request (PR)](https://github.com/adamziel/blueprints/pulls) with 
 The PR should contain:
 
 -   A single `blueprint.json` file under the path `blueprints/your-blueprint-name/blueprint.json` (like [the examples here](https://github.com/wordpress/blueprints/tree/trunk/blueprints)).
--   All the static files (WXR, ZIP, JPG, etc.) your Blueprint references. The static files must be loaded via the `https://raw.githubusercontent.com` URL pointing to your branch. `raw.githubusercontent.com` is a service that allows you to serve files directly from your GitHub repository. This is useful for loading static files in Blueprints. The URLs follow the `raw.githubusercontent.com/${user}/${repo}/${branch}/${path}` pattern.
+-   All the static files (WXR, ZIP, JPG, etc.) your Blueprint references. Load each file from the pull request's repository and branch with a URL following the `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path}` pattern. For a pull request from a fork, `${user}/${repo}` is the fork—not `WordPress/blueprints`—because the branch and file do not exist upstream until the pull request is merged. Use `raw.githubusercontent.com`, not a `github.com/.../blob/...` page, which returns HTML instead of the file.
 
-For example, if you want to load a content-export.xml file, you create a new folder in the blueprints directory, /woocommerce-subscription (the name should correpond to the name of the blueprint). The folder must hold two files:
+For example, to load `content-export.xml`, create a `blueprints/woocommerce-subscriptions` directory containing:
 
 -   A `blueprints/woocommerce-subscriptions/blueprint.json` file
--   A `blueprints/woocommerce-subscription/content-export.xml` file
+-   A `blueprints/woocommerce-subscriptions/content-export.xml` file
 
-Assuming your branch is named `/woo-subscription/`, the Blueprint should reference as follows:
+If the pull request comes from `example-contributor/blueprints` on the `feature/woo-subscription` branch, reference the file as follows:
 
 ```json
 {
@@ -31,12 +31,14 @@ Assuming your branch is named `/woo-subscription/`, the Blueprint should referen
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-subscriptions/blueprints/woocommerce-subscriptions/content-export.xml"
+				"url": "https://raw.githubusercontent.com/example-contributor/blueprints/feature/woo-subscription/blueprints/woocommerce-subscriptions/content-export.xml"
 			}
 		}
 	]
 }
 ```
+
+Pull request validation checks that raw URLs use the exact head repository and branch, or upstream `trunk`, and can be fetched. After a pull request is merged, repository automation rewrites fork and feature-branch attachment URLs to the upstream `trunk` form.
 
 By submitting a Blueprint, you agree to license it under [GPLv2 or later license](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ If the pull request comes from `example-contributor/blueprints` on the `feature/
 }
 ```
 
-Pull request validation checks that raw URLs use the exact head repository and branch, or upstream `trunk`, and can be fetched. After a pull request is merged, repository automation rewrites fork and feature-branch attachment URLs to the upstream `trunk` form.
+Pull request validation checks that raw URLs use the exact head repository and branch, or upstream `trunk`, and can be fetched. URLs from the pull request branch must point to files inside the same Blueprint directory. After a pull request is merged, repository automation rewrites fork and feature-branch attachment URLs to the upstream `trunk` form.
 
 By submitting a Blueprint, you agree to license it under [GPLv2 or later license](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "shots": "tsx scripts/screenshot-blueprints.ts",
+    "test:pr-blueprint-urls": "node --test scripts/lib/raw-github-url.test.js && python3 reindex_postprocess.py --test",
     "validate:pr-blueprints": "node scripts/validate-pr-blueprints.js",
     "validate:my-wordpress-json": "node scripts/validate-my-wordpress-json.js"
   },

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -285,16 +285,20 @@ def map_url_resources(blueprint_fragment, mapper):
 
 def branch_url_mapper(url):
     """
-    Rewrite a raw.githubusercontent.com URL to point to the trunk branch.
+    Rewrite a raw GitHub Blueprint attachment URL to upstream trunk.
 
-    >>> branch_url_mapper('https://raw.githubusercontent.com/wordpress/blueprints/my-branch/blueprint.json')
-    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json'
-    >>> branch_url_mapper('https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json')
-    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/contributor/blueprints/user/feature/blueprints/woo-shipping/sample_products.xml')
+    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/data.xml')
+    'https://raw.githubusercontent.com/example/external/main/data.xml'
     """
-    if not url.startswith("https://raw.githubusercontent.com"):
+    match = re.match(
+        r'^https://raw\.githubusercontent\.com/[^/]+/[^/]+/.+?/(blueprints/.+)$',
+        url
+    )
+    if not match:
         return url
-    return re.sub(r'https://raw.githubusercontent.com/wordpress/blueprints/([^/]+)', r'https://raw.githubusercontent.com/wordpress/blueprints/trunk', url)
+    return 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/' + match.group(1)
 
 if '--test' in sys.argv:
     print("Running doctests")

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -260,7 +260,11 @@ def rewrite_branch_urls_to_trunk():
         with open(path, 'r') as f:
             original_blueprint = f.read()
             json_blueprint = json.loads(original_blueprint)
-            map_url_resources(json_blueprint, branch_url_mapper)
+            blueprint_dir = os.path.dirname(path).replace('\\', '/')
+            map_url_resources(
+                json_blueprint,
+                lambda url: branch_url_mapper(url, blueprint_dir)
+            )
             new_blueprint = json.dumps(json_blueprint, indent="\t")
             # Only write if content changed to avoid unnecessary modifications
             if original_blueprint != new_blueprint:
@@ -283,27 +287,40 @@ def map_url_resources(blueprint_fragment, mapper):
         for item in blueprint_fragment:
             map_url_resources(item, mapper)
 
-def branch_url_mapper(url):
+def branch_url_mapper(url, blueprint_dir):
     """
-    Rewrite a raw GitHub Blueprint attachment URL to upstream trunk.
+    Rewrite a local raw GitHub Blueprint attachment URL to upstream trunk.
 
-    >>> branch_url_mapper('https://raw.githubusercontent.com/contributor/blueprints/user/feature/blueprints/woo-shipping/sample_products.xml')
+    >>> branch_url_mapper('HTTPS://RAW.GITHUBUSERCONTENT.COM/contributor/blueprints/user/feature/blueprints/woo-shipping/sample_products.xml', 'blueprints/woo-shipping')
     'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml'
-    >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/data.xml')
+    >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/data.xml', 'blueprints/woo-shipping')
     'https://raw.githubusercontent.com/example/external/main/data.xml'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/blueprints/not-in-this-repository.xml', 'blueprints/woo-shipping')
+    'https://raw.githubusercontent.com/example/external/main/blueprints/not-in-this-repository.xml'
     """
     match = re.match(
-        r'^https://raw\.githubusercontent\.com/[^/]+/[^/]+/.+?/(blueprints/.+)$',
+        r'(?i:^https://raw\.githubusercontent\.com/)[^/]+/[^/]+/.+?/(blueprints/.+)$',
         url
     )
     if not match:
         return url
-    return 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/' + match.group(1)
+    resource_path = match.group(1)
+    # A fork URL is a repository attachment only when the referenced file is
+    # present beside this Blueprint in the checkout. Preserve external URLs.
+    blueprint_prefix = blueprint_dir.rstrip('/') + '/'
+    if (
+        not resource_path.startswith(blueprint_prefix)
+        or os.path.normpath(resource_path).replace('\\', '/') != resource_path
+        or not os.path.isfile(resource_path)
+    ):
+        return url
+    return 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/' + resource_path
 
 if '--test' in sys.argv:
     print("Running doctests")
     import doctest
-    doctest.testmod()
+    failures, _ = doctest.testmod()
+    sys.exit(1 if failures else 0)
 else:
     print("Reindexing")
     index_data = build_json_index()

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -1,9 +1,11 @@
 import json
 import os
+import posixpath
 import re
 import subprocess
 import sys
 from functools import lru_cache
+from urllib.parse import quote, unquote, urlsplit
 
 highlighted_blueprints = {
     'Feed Reader with the Friends Plugin',
@@ -291,30 +293,61 @@ def branch_url_mapper(url, blueprint_dir):
     """
     Rewrite a local raw GitHub Blueprint attachment URL to upstream trunk.
 
-    >>> branch_url_mapper('HTTPS://RAW.GITHUBUSERCONTENT.COM/contributor/blueprints/user/feature/blueprints/woo-shipping/sample_products.xml', 'blueprints/woo-shipping')
+    >>> branch_url_mapper('HTTPS://RAW.GITHUBUSERCONTENT.COM/contributor/blueprints/feature/blueprints/fix/blueprints/woo-shipping/sample_products.xml', 'blueprints/woo-shipping')
     'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/contributor/blueprints/feature/blueprints/woo-shipping/sample_products.xml?cache=1', 'blueprints/woo-shipping')
+    'https://raw.githubusercontent.com/contributor/blueprints/feature/blueprints/woo-shipping/sample_products.xml?cache=1'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/contributor/blueprints/feature/blueprints/tt5-demo/tt5-demo-content.xml', 'blueprints/woo-shipping')
+    'https://raw.githubusercontent.com/contributor/blueprints/feature/blueprints/tt5-demo/tt5-demo-content.xml'
     >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/data.xml', 'blueprints/woo-shipping')
     'https://raw.githubusercontent.com/example/external/main/data.xml'
     >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/blueprints/not-in-this-repository.xml', 'blueprints/woo-shipping')
     'https://raw.githubusercontent.com/example/external/main/blueprints/not-in-this-repository.xml'
     """
-    match = re.match(
-        r'(?i:^https://raw\.githubusercontent\.com/)[^/]+/[^/]+/.+?/(blueprints/.+)$',
-        url
-    )
-    if not match:
+    try:
+        parsed = urlsplit(url)
+        port = parsed.port
+    except ValueError:
         return url
-    resource_path = match.group(1)
+
+    if (
+        parsed.scheme.lower() != 'https'
+        or (parsed.hostname or '').lower() != 'raw.githubusercontent.com'
+        or parsed.username
+        or parsed.password
+        or port not in (None, 443)
+        or parsed.query
+        or parsed.fragment
+    ):
+        return url
+
+    try:
+        normalized_path = posixpath.normpath(unquote(parsed.path, errors='strict'))
+    except UnicodeDecodeError:
+        return url
+
     # A fork URL is a repository attachment only when the referenced file is
     # present beside this Blueprint in the checkout. Preserve external URLs.
-    blueprint_prefix = blueprint_dir.rstrip('/') + '/'
+    blueprint_dir = blueprint_dir.replace('\\', '/').strip('/')
+    blueprint_prefix = blueprint_dir + '/'
+    marker = '/' + blueprint_prefix
+    marker_position = normalized_path.rfind(marker)
+    if marker_position < 0:
+        return url
+
+    resource_path = normalized_path[marker_position + 1:]
     if (
-        not resource_path.startswith(blueprint_prefix)
-        or os.path.normpath(resource_path).replace('\\', '/') != resource_path
+        not blueprint_dir
+        or posixpath.normpath(blueprint_dir) != blueprint_dir
+        or not resource_path.startswith(blueprint_prefix)
+        or posixpath.normpath(resource_path) != resource_path
         or not os.path.isfile(resource_path)
     ):
         return url
-    return 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/' + resource_path
+    return (
+        'https://raw.githubusercontent.com/wordpress/blueprints/trunk/'
+        + quote(resource_path, safe='/')
+    )
 
 if '--test' in sys.argv:
     print("Running doctests")

--- a/scripts/lib/raw-github-url.js
+++ b/scripts/lib/raw-github-url.js
@@ -1,9 +1,11 @@
-export function isAllowedRawGitHubUrl(rawUrl, allowedSources) {
+import path from 'node:path';
+
+export function matchAllowedRawGitHubUrl(rawUrl, allowedSources) {
 	let url;
 	try {
 		url = new URL(rawUrl);
 	} catch {
-		return false;
+		return null;
 	}
 
 	if (
@@ -11,31 +13,89 @@ export function isAllowedRawGitHubUrl(rawUrl, allowedSources) {
 		url.hostname.toLowerCase() !== 'raw.githubusercontent.com' ||
 		url.username ||
 		url.password ||
-		url.port
+		url.port ||
+		url.search ||
+		url.hash
+	) {
+		return null;
+	}
+
+	let pathname;
+	try {
+		pathname = decodeURIComponent(url.pathname);
+	} catch {
+		return null;
+	}
+
+	const [, owner, repository] = pathname.split('/');
+	if (!owner || !repository) {
+		return null;
+	}
+
+	const repositoryPathLength = `/${owner}/${repository}/`.length;
+	const refAndPath = pathname.slice(repositoryPathLength);
+
+	for (const source of allowedSources) {
+		const [allowedOwner, allowedRepository, ...extraParts] =
+			source.repository.split('/');
+
+		if (
+			!allowedOwner ||
+			!allowedRepository ||
+			extraParts.length > 0 ||
+			!source.ref
+		) {
+			continue;
+		}
+
+		if (
+			owner.toLowerCase() === allowedOwner.toLowerCase() &&
+			repository.toLowerCase() === allowedRepository.toLowerCase() &&
+			refAndPath.startsWith(`${source.ref}/`)
+		) {
+			const resourcePath = refAndPath.slice(source.ref.length + 1);
+			return resourcePath ? { source, resourcePath } : null;
+		}
+	}
+
+	return null;
+}
+
+export function isAllowedRawGitHubUrl(rawUrl, allowedSources) {
+	return matchAllowedRawGitHubUrl(rawUrl, allowedSources) !== null;
+}
+
+export function isBlueprintAttachmentPath(resourcePath, blueprintDir) {
+	const normalizedBlueprintDir = blueprintDir
+		.replaceAll('\\', '/')
+		.replace(/\/+$/, '');
+	if (
+		!normalizedBlueprintDir ||
+		path.posix.normalize(normalizedBlueprintDir) !==
+			normalizedBlueprintDir ||
+		resourcePath.includes('\0') ||
+		path.posix.normalize(resourcePath) !== resourcePath
 	) {
 		return false;
 	}
 
-	const [, owner, repository] = url.pathname.split('/');
-	if (!owner || !repository) {
+	return resourcePath.startsWith(`${normalizedBlueprintDir}/`);
+}
+
+export function isAllowedBlueprintResourceUrl(
+	rawUrl,
+	allowedSources,
+	blueprintDir,
+	isLocalFile
+) {
+	const match = matchAllowedRawGitHubUrl(rawUrl, allowedSources);
+	if (!match) {
 		return false;
 	}
 
-	const repositoryPathLength = `/${owner}/${repository}/`.length;
-	const refAndPath = url.pathname.slice(repositoryPathLength);
-
-	return allowedSources.some((source) => {
-		const [allowedOwner, allowedRepository, ...extraParts] =
-			source.repository.split('/');
-
-		if (!allowedOwner || !allowedRepository || extraParts.length > 0) {
-			return false;
-		}
-
-		return (
-			owner.toLowerCase() === allowedOwner.toLowerCase() &&
-			repository.toLowerCase() === allowedRepository.toLowerCase() &&
-			refAndPath.startsWith(`${source.ref}/`)
-		);
-	});
+	return (
+		match.source.kind !== 'head' ||
+		(isBlueprintAttachmentPath(match.resourcePath, blueprintDir) &&
+			isLocalFile(match.resourcePath))
+	);
 }

--- a/scripts/lib/raw-github-url.js
+++ b/scripts/lib/raw-github-url.js
@@ -1,0 +1,41 @@
+export function isAllowedRawGitHubUrl(rawUrl, allowedSources) {
+	let url;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		return false;
+	}
+
+	if (
+		url.protocol !== 'https:' ||
+		url.hostname.toLowerCase() !== 'raw.githubusercontent.com' ||
+		url.username ||
+		url.password ||
+		url.port
+	) {
+		return false;
+	}
+
+	const [, owner, repository] = url.pathname.split('/');
+	if (!owner || !repository) {
+		return false;
+	}
+
+	const repositoryPathLength = `/${owner}/${repository}/`.length;
+	const refAndPath = url.pathname.slice(repositoryPathLength);
+
+	return allowedSources.some((source) => {
+		const [allowedOwner, allowedRepository, ...extraParts] =
+			source.repository.split('/');
+
+		if (!allowedOwner || !allowedRepository || extraParts.length > 0) {
+			return false;
+		}
+
+		return (
+			owner.toLowerCase() === allowedOwner.toLowerCase() &&
+			repository.toLowerCase() === allowedRepository.toLowerCase() &&
+			refAndPath.startsWith(`${source.ref}/`)
+		);
+	});
+}

--- a/scripts/lib/raw-github-url.test.js
+++ b/scripts/lib/raw-github-url.test.js
@@ -1,14 +1,21 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { isAllowedRawGitHubUrl } from './raw-github-url.js';
+import {
+	isAllowedBlueprintResourceUrl,
+	isAllowedRawGitHubUrl,
+	isBlueprintAttachmentPath,
+	matchAllowedRawGitHubUrl,
+} from './raw-github-url.js';
 
 const allowedSources = [
 	{
+		kind: 'head',
 		repository: 'WordPress/blueprints',
 		ref: 'feature/validate-urls',
 	},
 	{
+		kind: 'trunk',
 		repository: 'wordpress/blueprints',
 		ref: 'trunk',
 	},
@@ -48,5 +55,114 @@ test('rejects other repositories and near-matching refs', () => {
 			allowedSources
 		),
 		false
+	);
+});
+
+test('returns the matched source and decoded resource path', () => {
+	const match = matchAllowedRawGitHubUrl(
+		'https://raw.githubusercontent.com/WordPress/blueprints/feature/validate-urls/blueprints/example/file%20name.xml',
+		allowedSources
+	);
+
+	assert.equal(match?.source.kind, 'head');
+	assert.equal(match?.resourcePath, 'blueprints/example/file name.xml');
+});
+
+test('supports refs containing a blueprints path segment', () => {
+	assert.equal(
+		isAllowedRawGitHubUrl(
+			'https://raw.githubusercontent.com/WordPress/blueprints/feature/blueprints/fix/blueprints/example/file.xml',
+			[
+				{
+					kind: 'head',
+					repository: 'WordPress/blueprints',
+					ref: 'feature/blueprints/fix',
+				},
+			]
+		),
+		true
+	);
+});
+
+test('rejects query strings and fragments', () => {
+	for (const suffix of ['?cache=1', '#download']) {
+		assert.equal(
+			isAllowedRawGitHubUrl(
+				`https://raw.githubusercontent.com/WordPress/blueprints/feature/validate-urls/blueprints/example/file.xml${suffix}`,
+				allowedSources
+			),
+			false
+		);
+	}
+});
+
+test('only treats canonical files inside the current Blueprint as attachments', () => {
+	assert.equal(
+		isBlueprintAttachmentPath(
+			'blueprints/example/file.xml',
+			'blueprints/example'
+		),
+		true
+	);
+	assert.equal(
+		isBlueprintAttachmentPath(
+			'blueprints/other/file.xml',
+			'blueprints/example'
+		),
+		false
+	);
+	assert.equal(
+		isBlueprintAttachmentPath(
+			'blueprints/example/../other/file.xml',
+			'blueprints/example'
+		),
+		false
+	);
+});
+
+test('only accepts existing same-Blueprint files from the pull request head', () => {
+	const isLocalFile = (resourcePath) =>
+		resourcePath === 'blueprints/example/file.xml';
+	const headUrl =
+		'https://raw.githubusercontent.com/WordPress/blueprints/feature/validate-urls/';
+
+	assert.equal(
+		isAllowedBlueprintResourceUrl(
+			`${headUrl}blueprints/example/file.xml`,
+			allowedSources,
+			'blueprints/example',
+			isLocalFile
+		),
+		true
+	);
+	assert.equal(
+		isAllowedBlueprintResourceUrl(
+			`${headUrl}blueprints/other/file.xml`,
+			allowedSources,
+			'blueprints/example',
+			isLocalFile
+		),
+		false
+	);
+	assert.equal(
+		isAllowedBlueprintResourceUrl(
+			`${headUrl}blueprints/example/missing.xml`,
+			allowedSources,
+			'blueprints/example',
+			isLocalFile
+		),
+		false
+	);
+});
+
+test('does not require an upstream trunk URL to exist in the current Blueprint directory', () => {
+	assert.equal(
+		isAllowedBlueprintResourceUrl(
+			'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/other/file.xml',
+			allowedSources,
+			'blueprints/example',
+			() => false
+		),
+		true
 	);
 });

--- a/scripts/lib/raw-github-url.test.js
+++ b/scripts/lib/raw-github-url.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isAllowedRawGitHubUrl } from './raw-github-url.js';
+
+const allowedSources = [
+	{
+		repository: 'WordPress/blueprints',
+		ref: 'feature/validate-urls',
+	},
+	{
+		repository: 'wordpress/blueprints',
+		ref: 'trunk',
+	},
+];
+
+test('accepts repository names with different capitalization', () => {
+	assert.equal(
+		isAllowedRawGitHubUrl(
+			'HTTPS://RAW.GITHUBUSERCONTENT.COM/wordpress/BLUEPRINTS/feature/validate-urls/blueprints/example/file.xml',
+			allowedSources
+		),
+		true
+	);
+});
+
+test('keeps refs case-sensitive', () => {
+	assert.equal(
+		isAllowedRawGitHubUrl(
+			'https://raw.githubusercontent.com/WordPress/blueprints/Feature/validate-urls/blueprints/example/file.xml',
+			allowedSources
+		),
+		false
+	);
+});
+
+test('rejects other repositories and near-matching refs', () => {
+	assert.equal(
+		isAllowedRawGitHubUrl(
+			'https://raw.githubusercontent.com/example/blueprints/feature/validate-urls/blueprints/example/file.xml',
+			allowedSources
+		),
+		false
+	);
+	assert.equal(
+		isAllowedRawGitHubUrl(
+			'https://raw.githubusercontent.com/WordPress/blueprints/feature/validate-urls-extended/blueprints/example/file.xml',
+			allowedSources
+		),
+		false
+	);
+});

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -146,7 +146,8 @@ async function main() {
 					blueprintJsonPath,
 					[
 						`URL is not allowed or could not be fetched: ${url}`,
-						'URLs in blueprint.json must use the current branch or trunk.',
+						'URLs in blueprint.json must be fetchable and use the current branch or trunk.',
+						'Example: https://raw.githubusercontent.com/wordpress/blueprints/CURRENT_BRANCH_OR_TRUNK/blueprints/BLUEPRINT_DIRECTORY/FILE_NAME',
 					].join('\n')
 				);
 			}

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -46,6 +46,26 @@ function getTouchedBlueprintDirectories() {
 	return [...blueprintDirs].sort();
 }
 
+async function isUrlValid(url, allowedPrefixes) {
+	if (!url.startsWith('https://') && !url.startsWith('http://')) {
+		return true;
+	}
+
+	if (!allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+		return false;
+	}
+
+	try {
+		const response = await fetch(url, {
+			method: 'HEAD',
+			signal: AbortSignal.timeout(10_000),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
 function findUrlsRequiringBranchPrefix(value) {
 	if (Array.isArray(value)) {
 		return value.flatMap(findUrlsRequiringBranchPrefix);
@@ -77,6 +97,10 @@ async function main() {
 	}
 
 	const currentBranch = getCurrentBranch();
+	const allowedUrlPrefixes = [currentBranch, 'trunk'].map(
+		(branch) =>
+			`https://raw.githubusercontent.com/wordpress/blueprints/${branch}/`
+	);
 	let validateBlueprint;
 	let failed = false;
 
@@ -107,13 +131,13 @@ async function main() {
 			continue;
 		}
 
-		const invalidUrls = findUrlsRequiringBranchPrefix(blueprint).filter(
-			(url) =>
-				(url.startsWith('https://') || url.startsWith('http://')) &&
-				!url.startsWith(
-					`https://raw.githubusercontent.com/wordpress/blueprints/${currentBranch}/`
+		const invalidUrls = (
+			await Promise.all(
+				findUrlsRequiringBranchPrefix(blueprint).map(async (url) =>
+					(await isUrlValid(url, allowedUrlPrefixes)) ? null : url
 				)
-		);
+			)
+		).filter(Boolean);
 
 		if (invalidUrls.length > 0) {
 			failed = true;
@@ -121,8 +145,8 @@ async function main() {
 				reportError(
 					blueprintJsonPath,
 					[
-						`URL is not allowed: ${url}`,
-						`URLs in blueprint.json must start with https://raw.githubusercontent.com/wordpress/blueprints/${currentBranch}/`,
+						`URL is not allowed or could not be fetched: ${url}`,
+						'URLs in blueprint.json must use the current branch or trunk.',
 					].join('\n')
 				);
 			}

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -7,7 +7,7 @@ import {
 	readJson,
 	reportError,
 } from './lib/json-validation.js';
-import { isAllowedRawGitHubUrl } from './lib/raw-github-url.js';
+import { isAllowedBlueprintResourceUrl } from './lib/raw-github-url.js';
 
 function getPullRequestSource() {
 	const repository = process.env.PR_HEAD_REPOSITORY;
@@ -50,12 +50,27 @@ function getTouchedBlueprintDirectories() {
 	return [...blueprintDirs].sort();
 }
 
-async function isUrlValid(url, allowedSources) {
+function isLocalFile(filePath) {
+	try {
+		return fs.statSync(filePath).isFile();
+	} catch {
+		return false;
+	}
+}
+
+async function isUrlValid(url, allowedSources, blueprintDir) {
 	if (!/^https?:\/\//i.test(url)) {
 		return true;
 	}
 
-	if (!isAllowedRawGitHubUrl(url, allowedSources)) {
+	if (
+		!isAllowedBlueprintResourceUrl(
+			url,
+			allowedSources,
+			blueprintDir,
+			isLocalFile
+		)
+	) {
 		return false;
 	}
 
@@ -102,8 +117,8 @@ async function main() {
 
 	const { repository, ref } = getPullRequestSource();
 	const allowedUrlSources = [
-		{ repository, ref },
-		{ repository: 'wordpress/blueprints', ref: 'trunk' },
+		{ kind: 'head', repository, ref },
+		{ kind: 'trunk', repository: 'wordpress/blueprints', ref: 'trunk' },
 	];
 	const allowedUrlPrefixes = allowedUrlSources.map(
 		(source) =>
@@ -142,7 +157,9 @@ async function main() {
 		const invalidUrls = (
 			await Promise.all(
 				findUrlsRequiringBranchPrefix(blueprint).map(async (url) =>
-					(await isUrlValid(url, allowedUrlSources)) ? null : url
+					(await isUrlValid(url, allowedUrlSources, blueprintDir))
+						? null
+						: url
 				)
 			)
 		).filter(Boolean);
@@ -155,6 +172,7 @@ async function main() {
 					[
 						`URL is not allowed or could not be fetched: ${url}`,
 						'URLs must be fetchable and use the pull request repository and ref, or upstream trunk.',
+						'Pull request URLs must point to files inside the current Blueprint directory.',
 						`Expected: ${allowedUrlPrefixes.join(' or ')}`,
 					].join('\n')
 				);

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -7,6 +7,7 @@ import {
 	readJson,
 	reportError,
 } from './lib/json-validation.js';
+import { isAllowedRawGitHubUrl } from './lib/raw-github-url.js';
 
 function getPullRequestSource() {
 	const repository = process.env.PR_HEAD_REPOSITORY;
@@ -49,12 +50,12 @@ function getTouchedBlueprintDirectories() {
 	return [...blueprintDirs].sort();
 }
 
-async function isUrlValid(url, allowedPrefixes) {
-	if (!url.startsWith('https://') && !url.startsWith('http://')) {
+async function isUrlValid(url, allowedSources) {
+	if (!/^https?:\/\//i.test(url)) {
 		return true;
 	}
 
-	if (!allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+	if (!isAllowedRawGitHubUrl(url, allowedSources)) {
 		return false;
 	}
 
@@ -100,10 +101,14 @@ async function main() {
 	}
 
 	const { repository, ref } = getPullRequestSource();
-	const allowedUrlPrefixes = [
-		`https://raw.githubusercontent.com/${repository}/${ref}/`,
-		'https://raw.githubusercontent.com/wordpress/blueprints/trunk/',
+	const allowedUrlSources = [
+		{ repository, ref },
+		{ repository: 'wordpress/blueprints', ref: 'trunk' },
 	];
+	const allowedUrlPrefixes = allowedUrlSources.map(
+		(source) =>
+			`https://raw.githubusercontent.com/${source.repository}/${source.ref}/`
+	);
 	let validateBlueprint;
 	let failed = false;
 
@@ -137,7 +142,7 @@ async function main() {
 		const invalidUrls = (
 			await Promise.all(
 				findUrlsRequiringBranchPrefix(blueprint).map(async (url) =>
-					(await isUrlValid(url, allowedUrlPrefixes)) ? null : url
+					(await isUrlValid(url, allowedUrlSources)) ? null : url
 				)
 			)
 		).filter(Boolean);

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -8,14 +8,17 @@ import {
 	reportError,
 } from './lib/json-validation.js';
 
-function getCurrentBranch() {
-	const currentBranch = process.env.GITHUB_BRANCH || process.env.GITHUB_HEAD_REF;
+function getPullRequestSource() {
+	const repository = process.env.PR_HEAD_REPOSITORY;
+	const ref = process.env.PR_HEAD_REF;
 
-	if (!currentBranch) {
-		throw new Error('Could not determine the current branch for URL validation.');
+	if (!repository || !ref) {
+		throw new Error(
+			'PR_HEAD_REPOSITORY and PR_HEAD_REF must be provided for URL validation.'
+		);
 	}
 
-	return currentBranch;
+	return { repository, ref };
 }
 
 function getChangedFiles() {
@@ -96,11 +99,11 @@ async function main() {
 		return;
 	}
 
-	const currentBranch = getCurrentBranch();
-	const allowedUrlPrefixes = [currentBranch, 'trunk'].map(
-		(branch) =>
-			`https://raw.githubusercontent.com/wordpress/blueprints/${branch}/`
-	);
+	const { repository, ref } = getPullRequestSource();
+	const allowedUrlPrefixes = [
+		`https://raw.githubusercontent.com/${repository}/${ref}/`,
+		'https://raw.githubusercontent.com/wordpress/blueprints/trunk/',
+	];
 	let validateBlueprint;
 	let failed = false;
 
@@ -146,8 +149,8 @@ async function main() {
 					blueprintJsonPath,
 					[
 						`URL is not allowed or could not be fetched: ${url}`,
-						'URLs in blueprint.json must be fetchable and use the current branch or trunk.',
-						'Example: https://raw.githubusercontent.com/wordpress/blueprints/CURRENT_BRANCH_OR_TRUNK/blueprints/BLUEPRINT_DIRECTORY/FILE_NAME',
+						'URLs must be fetchable and use the pull request repository and ref, or upstream trunk.',
+						`Expected: ${allowedUrlPrefixes.join(' or ')}`,
 					].join('\n')
 				);
 			}


### PR DESCRIPTION
## Summary

Allows PR Blueprint validation to accept raw GitHub URLs from the current branch or `trunk` and verifies that allowed URLs remain fetchable.

## Rationale

Blueprints may legitimately reference files already merged to `trunk`, while branch-local files still need to resolve before merge.

## Implementation details

Adds allowed-prefix construction, concurrent `HEAD` checks with 10-second timeouts, and clearer errors with a valid URL example.

## Testing Instructions

Draft PR #222 provides an end-to-end fork validation case using `blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json`:

1. The test branch was created directly from `trunk` with only the Blueprint patch. Its raw WXR attachment was reachable, but [the trunk validator failed](https://github.com/WordPress/blueprints/actions/runs/29476406551) because it required the nonexistent `wordpress/blueprints/test-pr-221-validator` branch.
2. The unchanged Blueprint patch was rebased onto this PR. [The next validation run passed](https://github.com/WordPress/blueprints/actions/runs/29476446814) with `PR_HEAD_REPOSITORY=bgrgicak/blueprints` and `PR_HEAD_REF=test-pr-221-validator`.

For a local smoke test, run:

```bash
CHANGED_FILES=blueprints/tt5-demo/blueprint.json \
PR_HEAD_REPOSITORY=bgrgicak/blueprints \
PR_HEAD_REF=bgrgicak/resolve-pr-220-thread \
npm run validate:pr-blueprints
```

Confirm the output includes `Valid Blueprint: blueprints/tt5-demo/blueprint.json`.
