### PR TITLE
[Blueprints] Update theme demo resources

### DIFF
--- a/.github/workflows/has-valid-blueprint-json.yml
+++ b/.github/workflows/has-valid-blueprint-json.yml
@@ -8,7 +8,8 @@ jobs:
         runs-on: ubuntu-latest
 
         env:
-            GITHUB_BRANCH: ${{ github.event.pull_request.head.ref }}
+            PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+            PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
             GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
             BLUEPRINT_SCHEMA_URL: "https://raw.githubusercontent.com/WordPress/wordpress-playground/trunk/packages/playground/blueprints/public/blueprint-schema.json"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,14 +15,14 @@ Submit [a Pull Request (PR)](https://github.com/adamziel/blueprints/pulls) with 
 The PR should contain:
 
 -   A single `blueprint.json` file under the path `blueprints/your-blueprint-name/blueprint.json` (like [the examples here](https://github.com/wordpress/blueprints/tree/trunk/blueprints)).
--   All the static files (WXR, ZIP, JPG, etc.) your Blueprint references. The static files must be loaded via the `https://raw.githubusercontent.com` URL pointing to your branch. `raw.githubusercontent.com` is a service that allows you to serve files directly from your GitHub repository. This is useful for loading static files in Blueprints. The URLs follow the `raw.githubusercontent.com/${user}/${repo}/${branch}/${path}` pattern.
+-   All the static files (WXR, ZIP, JPG, etc.) your Blueprint references. Load each file from the pull request's repository and branch with a URL following the `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${path}` pattern. For a pull request from a fork, `${user}/${repo}` is the fork—not `WordPress/blueprints`—because the branch and file do not exist upstream until the pull request is merged. Use `raw.githubusercontent.com`, not a `github.com/.../blob/...` page, which returns HTML instead of the file.
 
-For example, if you want to load a content-export.xml file, you create a new folder in the blueprints directory, /woocommerce-subscription (the name should correpond to the name of the blueprint). The folder must hold two files:
+For example, to load `content-export.xml`, create a `blueprints/woocommerce-subscriptions` directory containing:
 
 -   A `blueprints/woocommerce-subscriptions/blueprint.json` file
--   A `blueprints/woocommerce-subscription/content-export.xml` file
+-   A `blueprints/woocommerce-subscriptions/content-export.xml` file
 
-Assuming your branch is named `/woo-subscription/`, the Blueprint should reference as follows:
+If the pull request comes from `example-contributor/blueprints` on the `feature/woo-subscription` branch, reference the file as follows:
 
 ```json
 {
@@ -31,12 +31,14 @@ Assuming your branch is named `/woo-subscription/`, the Blueprint should referen
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/wordpress/blueprints/woo-subscriptions/blueprints/woocommerce-subscriptions/content-export.xml"
+				"url": "https://raw.githubusercontent.com/example-contributor/blueprints/feature/woo-subscription/blueprints/woocommerce-subscriptions/content-export.xml"
 			}
 		}
 	]
 }
 ```
+
+Pull request validation checks that raw URLs use the exact head repository and branch, or upstream `trunk`, and can be fetched. After a pull request is merged, repository automation rewrites fork and feature-branch attachment URLs to the upstream `trunk` form.
 
 By submitting a Blueprint, you agree to license it under [GPLv2 or later license](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html).
 

--- a/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
+++ b/blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json
@@ -14,8 +14,8 @@
 		},
 		{
 			"step": "writeFile",
-			"path": "/wordpress/wp-content/mu-plugins/rewrite.php",
-			"data": "<?php /* Use pretty permalinks */ add_action( 'after_setup_theme', function() { global $wp_rewrite; $wp_rewrite->set_permalink_structure('/%postname%/'); $wp_rewrite->flush_rules(); } );"
+			"path": "/wordpress/wp-content/mu-plugins/demo-body-class.php",
+			"data": "<?php add_filter( 'body_class', function ( $classes ) { $classes[] = 'playground-demo'; return $classes; } );"
 		},
 		{
 			"step": "updateUserMeta",
@@ -29,8 +29,10 @@
 		{
 			"step": "installTheme",
 			"themeData": {
-				"resource": "url",
-				"url": "https://github.com/richtabor/kanso/archive/refs/heads/main.zip"
+				"resource": "git:directory",
+				"url": "https://github.com/richtabor/kanso.git",
+				"ref": "main",
+				"path": "/"
 			},
 			"options": {
 				"activate": true
@@ -40,7 +42,7 @@
 			"step": "importWxr",
 			"file": {
 				"resource": "url",
-				"url": "https://github.com/WordPress/blueprints/blob/trunk/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
+				"url": "https://raw.githubusercontent.com/bgrgicak/blueprints/test-pr-221-validator/blueprints/install-activate-setup-theme-from-gh-repo/blueprint-content.xml"
 			}
 		}
 	],

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -285,16 +285,20 @@ def map_url_resources(blueprint_fragment, mapper):
 
 def branch_url_mapper(url):
     """
-    Rewrite a raw.githubusercontent.com URL to point to the trunk branch.
+    Rewrite a raw GitHub Blueprint attachment URL to upstream trunk.
 
-    >>> branch_url_mapper('https://raw.githubusercontent.com/wordpress/blueprints/my-branch/blueprint.json')
-    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json'
-    >>> branch_url_mapper('https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json')
-    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprint.json'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/contributor/blueprints/user/feature/blueprints/woo-shipping/sample_products.xml')
+    'https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/woo-shipping/sample_products.xml'
+    >>> branch_url_mapper('https://raw.githubusercontent.com/example/external/main/data.xml')
+    'https://raw.githubusercontent.com/example/external/main/data.xml'
     """
-    if not url.startswith("https://raw.githubusercontent.com"):
+    match = re.match(
+        r'^https://raw\.githubusercontent\.com/[^/]+/[^/]+/.+?/(blueprints/.+)$',
+        url
+    )
+    if not match:
         return url
-    return re.sub(r'https://raw.githubusercontent.com/wordpress/blueprints/([^/]+)', r'https://raw.githubusercontent.com/wordpress/blueprints/trunk', url)
+    return 'https://raw.githubusercontent.com/wordpress/blueprints/trunk/' + match.group(1)
 
 if '--test' in sys.argv:
     print("Running doctests")

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -146,7 +146,8 @@ async function main() {
 					blueprintJsonPath,
 					[
 						`URL is not allowed or could not be fetched: ${url}`,
-						'URLs in blueprint.json must use the current branch or trunk.',
+						'URLs in blueprint.json must be fetchable and use the current branch or trunk.',
+						'Example: https://raw.githubusercontent.com/wordpress/blueprints/CURRENT_BRANCH_OR_TRUNK/blueprints/BLUEPRINT_DIRECTORY/FILE_NAME',
 					].join('\n')
 				);
 			}

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -46,6 +46,26 @@ function getTouchedBlueprintDirectories() {
 	return [...blueprintDirs].sort();
 }
 
+async function isUrlValid(url, allowedPrefixes) {
+	if (!url.startsWith('https://') && !url.startsWith('http://')) {
+		return true;
+	}
+
+	if (!allowedPrefixes.some((prefix) => url.startsWith(prefix))) {
+		return false;
+	}
+
+	try {
+		const response = await fetch(url, {
+			method: 'HEAD',
+			signal: AbortSignal.timeout(10_000),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
 function findUrlsRequiringBranchPrefix(value) {
 	if (Array.isArray(value)) {
 		return value.flatMap(findUrlsRequiringBranchPrefix);
@@ -77,6 +97,10 @@ async function main() {
 	}
 
 	const currentBranch = getCurrentBranch();
+	const allowedUrlPrefixes = [currentBranch, 'trunk'].map(
+		(branch) =>
+			`https://raw.githubusercontent.com/wordpress/blueprints/${branch}/`
+	);
 	let validateBlueprint;
 	let failed = false;
 
@@ -107,13 +131,13 @@ async function main() {
 			continue;
 		}
 
-		const invalidUrls = findUrlsRequiringBranchPrefix(blueprint).filter(
-			(url) =>
-				(url.startsWith('https://') || url.startsWith('http://')) &&
-				!url.startsWith(
-					`https://raw.githubusercontent.com/wordpress/blueprints/${currentBranch}/`
+		const invalidUrls = (
+			await Promise.all(
+				findUrlsRequiringBranchPrefix(blueprint).map(async (url) =>
+					(await isUrlValid(url, allowedUrlPrefixes)) ? null : url
 				)
-		);
+			)
+		).filter(Boolean);
 
 		if (invalidUrls.length > 0) {
 			failed = true;
@@ -121,8 +145,8 @@ async function main() {
 				reportError(
 					blueprintJsonPath,
 					[
-						`URL is not allowed: ${url}`,
-						`URLs in blueprint.json must start with https://raw.githubusercontent.com/wordpress/blueprints/${currentBranch}/`,
+						`URL is not allowed or could not be fetched: ${url}`,
+						'URLs in blueprint.json must use the current branch or trunk.',
 					].join('\n')
 				);
 			}

--- a/scripts/validate-pr-blueprints.js
+++ b/scripts/validate-pr-blueprints.js
@@ -8,14 +8,17 @@ import {
 	reportError,
 } from './lib/json-validation.js';
 
-function getCurrentBranch() {
-	const currentBranch = process.env.GITHUB_BRANCH || process.env.GITHUB_HEAD_REF;
+function getPullRequestSource() {
+	const repository = process.env.PR_HEAD_REPOSITORY;
+	const ref = process.env.PR_HEAD_REF;
 
-	if (!currentBranch) {
-		throw new Error('Could not determine the current branch for URL validation.');
+	if (!repository || !ref) {
+		throw new Error(
+			'PR_HEAD_REPOSITORY and PR_HEAD_REF must be provided for URL validation.'
+		);
 	}
 
-	return currentBranch;
+	return { repository, ref };
 }
 
 function getChangedFiles() {
@@ -96,11 +99,11 @@ async function main() {
 		return;
 	}
 
-	const currentBranch = getCurrentBranch();
-	const allowedUrlPrefixes = [currentBranch, 'trunk'].map(
-		(branch) =>
-			`https://raw.githubusercontent.com/wordpress/blueprints/${branch}/`
-	);
+	const { repository, ref } = getPullRequestSource();
+	const allowedUrlPrefixes = [
+		`https://raw.githubusercontent.com/${repository}/${ref}/`,
+		'https://raw.githubusercontent.com/wordpress/blueprints/trunk/',
+	];
 	let validateBlueprint;
 	let failed = false;
 
@@ -146,8 +149,8 @@ async function main() {
 					blueprintJsonPath,
 					[
 						`URL is not allowed or could not be fetched: ${url}`,
-						'URLs in blueprint.json must be fetchable and use the current branch or trunk.',
-						'Example: https://raw.githubusercontent.com/wordpress/blueprints/CURRENT_BRANCH_OR_TRUNK/blueprints/BLUEPRINT_DIRECTORY/FILE_NAME',
+						'URLs must be fetchable and use the pull request repository and ref, or upstream trunk.',
+						`Expected: ${allowedUrlPrefixes.join(' or ')}`,
 					].join('\n')
 				);
 			}


### PR DESCRIPTION
## Summary

Removes the stale `flush_rules()` example from the theme demo Blueprint and uses valid resource forms for the Kanso theme and WXR content.

## Rationale

This extracts the Blueprint-only change from #220 and provides an end-to-end fork-URL validation case for #221. The raw WXR URL must resolve from this pull request's fork and branch before the change is merged.

## Implementation details

- Replaces the rewrite-rules mu-plugin with a harmless demo body-class filter.
- Loads Kanso through `git:directory`.
- Loads the WXR attachment from this pull request's head repository and ref.

This draft is stacked on #221 so the Blueprint can reference an attachment from its fork branch. Once #221 merges, this PR can be rebased onto `trunk` and will contain only the Blueprint change.

## Testing Instructions

1. `git diff --check` passes.
2. `npx prettier --check blueprints/install-activate-setup-theme-from-gh-repo/blueprint.json` passes.
3. [The trunk-based validation run failed as expected](https://github.com/WordPress/blueprints/actions/runs/29476406551), requiring a raw URL from the nonexistent `wordpress/blueprints/test-pr-221-validator` branch.
4. The Blueprint patch was left unchanged and rebased onto #221.
5. [The stacked validation run passes](https://github.com/WordPress/blueprints/actions/runs/29476446814), using `bgrgicak/blueprints` and `test-pr-221-validator` from the pull request event.
