### PR TITLE
Add WooCommerce test store blueprints (Hello Elementor and Astra)

### DIFF
--- a/blueprints/woocommerce-test-store-astra/README.md
+++ b/blueprints/woocommerce-test-store-astra/README.md
@@ -1,0 +1,47 @@
+## WooCommerce Store (Astra)
+
+A WooCommerce store set up with a **common, real-world configuration** — a
+lifelike environment for testing plugins, themes, and WooCommerce itself against
+something closer to a production store than a bare install.
+
+It pairs with
+[WooCommerce Store (Hello Elementor)](../woocommerce-test-store-hello-elementor/),
+which uses a different theme and locale. Between the two they cover the most
+common theme families and two locale profiles (period-decimal USD and
+comma-decimal EUR).
+
+### What it sets up
+
+- **Theme:** Astra (one of the most common themes on WooCommerce stores).
+- **WooCommerce:** latest stable, plus a set of the most widely-used extensions:
+  Elementor (page builder), Yoast SEO, Contact Form 7, WP Mail SMTP, Site Kit by
+  Google, Google Listings & Ads, Jetpack, WooCommerce PayPal Payments, WooCommerce
+  Stripe Gateway, WooPayments, Code Snippets, Loco Translate, LiteSpeed Cache,
+  WPForms Lite, Classic Editor.
+- **Locale:** USD currency with US formatting (`$1,234.56`), store based in the
+  United States — the US checkout requires a state field, exercising a different
+  address form than the EUR/DE variant.
+- **Content:** three sample products (a simple product, a product on sale, and a
+  virtual/downloadable product), plus the standard WooCommerce pages.
+- Guest checkout enabled, pretty permalinks, onboarding wizard skipped.
+
+### Notes
+
+- **All extensions are active by default.** On a resource-constrained host the
+  admin can feel slow with this many plugins active; deactivate a few for a
+  snappier experience, e.g. `wp plugin deactivate litespeed-cache wpforms-lite
+  classic-editor`, or from **Plugins** in wp-admin. Nothing depends on all of
+  them being active.
+- **Landing page is the shop** (`/shop/`), a server-rendered page that loads
+  quickly. The WooCommerce Analytics dashboard is heavier and may take a moment.
+- Plugins are installed first and activated at the end, so the sample content is
+  created on a clean WooCommerce-only stack before the other extensions load.
+
+### Changing the WooCommerce version
+
+WooCommerce installs from the wordpress.org plugin directory, so it's always the
+**latest stable** release. To target something else, replace the WooCommerce
+step's `pluginData` with a `url` resource:
+
+- **Pin a version:** `https://downloads.wordpress.org/plugin/woocommerce.<x.y.z>.zip`
+- **Nightly / trunk:** `https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip`

--- a/blueprints/woocommerce-test-store-astra/blueprint.json
+++ b/blueprints/woocommerce-test-store-astra/blueprint.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "WooCommerce Store (Astra)",
+    "description": "A WooCommerce store with a common configuration: the Astra theme, a set of widely-used extensions, USD / US locale, and sample products. A lifelike environment for testing against WooCommerce.",
+    "author": "alopezari",
+    "categories": [
+      "WooCommerce",
+      "Store"
+    ]
+  },
+  "landingPage": "/shop/",
+  "preferredVersions": {
+    "php": "8.3",
+    "wp": "7.0"
+  },
+  "phpExtensionBundles": [
+    "kitchen-sink"
+  ],
+  "features": {
+    "networking": true
+  },
+  "constants": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "WP_DEBUG_DISPLAY": false,
+    "WP_MEMORY_LIMIT": "512M",
+    "WP_MAX_MEMORY_LIMIT": "512M"
+  },
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installTheme",
+      "themeData": {
+        "resource": "wordpress.org/themes",
+        "slug": "astra"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "elementor"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wordpress-seo"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "contact-form-7"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wp-mail-smtp"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "google-site-kit"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "google-listings-and-ads"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "jetpack"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-paypal-payments"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-gateway-stripe"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "code-snippets"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "loco-translate"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "litespeed-cache"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-payments"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wpforms-lite"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "classic-editor"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "permalink_structure": "/%postname%/",
+        "blogname": "Test Store",
+        "woocommerce_currency": "USD",
+        "woocommerce_currency_pos": "left",
+        "woocommerce_price_thousand_sep": ",",
+        "woocommerce_price_decimal_sep": ".",
+        "woocommerce_price_num_decimals": "2",
+        "woocommerce_default_country": "US:CA",
+        "woocommerce_store_address": "660 4th Street",
+        "woocommerce_store_city": "San Francisco",
+        "woocommerce_store_postcode": "94107",
+        "woocommerce_enable_guest_checkout": "yes",
+        "woocommerce_api_enabled": "yes",
+        "woocommerce_calc_taxes": "no",
+        "woocommerce_enable_coupons": "yes",
+        "woocommerce_weight_unit": "lbs",
+        "woocommerce_dimension_unit": "in",
+        "woocommerce_onboarding_profile": {
+          "skipped": true
+        },
+        "woocommerce_task_list_hidden": "yes",
+        "woocommerce_task_list_welcome_modal_dismissed": "yes"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; wp_set_current_user(1); if ( ! function_exists('wp_insert_post') ) { exit(11); } if ( ! class_exists('WC_Product_Simple') ) { exit(12); } if ( class_exists('WC_Install') ) { WC_Install::create_pages(); } $mk = function($n,$p,$s,$o=[]){ $x=new WC_Product_Simple(); $x->set_name($n); $x->set_regular_price($p); $x->set_sku($s); $x->set_status('publish'); foreach($o as $k=>$v){$m=\"set_$k\"; if(method_exists($x,$m)){$x->$m($v);}} $x->save(); }; $mk('Cotton T-Shirt','24.99','TSHIRT-01',['manage_stock'=>true,'stock_quantity'=>50]); $mk('Ceramic Mug','12.50','MUG-01',['sale_price'=>'9.99','manage_stock'=>true,'stock_quantity'=>200]); $mk('Digital Guide (PDF)','7.00','GUIDE-01',['virtual'=>true,'downloadable'=>true]);"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; $n = count( get_posts(['post_type'=>'product','post_status'=>'publish','numberposts'=>-1]) ); $shop = get_option('woocommerce_shop_page_id'); if ( $n !== 3 ) { exit(21); } if ( ! $shop ) { exit(22); } echo \"VERIFIED products=$n shop_page=$shop\";"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; require_once ABSPATH.'wp-admin/includes/plugin.php'; wp_set_current_user(1); $want=['elementor', 'wordpress-seo', 'contact-form-7', 'wp-mail-smtp', 'google-site-kit', 'google-listings-and-ads', 'jetpack', 'woocommerce-paypal-payments', 'woocommerce-gateway-stripe', 'code-snippets', 'loco-translate', 'woocommerce-payments', 'litespeed-cache', 'wpforms-lite', 'classic-editor']; foreach (get_plugins() as $file=>$d){ $folder = (strpos($file,'/')!==false)?dirname($file):$file; if (in_array($folder,$want,true)){ activate_plugin($file); } } $active = array_filter(array_map(function($f){return (strpos($f,'/')!==false)?dirname($f):$f;}, (array)get_option('active_plugins'))); $missing = array_diff($want,$active); if (!empty($missing)){ echo 'MISSING '.implode(',',$missing); exit(31); } echo 'ACTIVATED '.count($want).' non-woo (active_total='.count((array)get_option('active_plugins')).')';"
+    }
+  ]
+}

--- a/blueprints/woocommerce-test-store-hello-elementor/README.md
+++ b/blueprints/woocommerce-test-store-hello-elementor/README.md
@@ -1,0 +1,46 @@
+## WooCommerce Store (Hello Elementor)
+
+A WooCommerce store set up with a **common, real-world configuration** — a
+lifelike environment for testing plugins, themes, and WooCommerce itself against
+something closer to a production store than a bare install.
+
+It pairs with [WooCommerce Store (Astra)](../woocommerce-test-store-astra/), which
+uses a different theme and locale. Between the two they cover the most common
+theme families and two locale profiles (comma-decimal EUR and period-decimal
+USD).
+
+### What it sets up
+
+- **Theme:** Hello Elementor + Elementor (the most common page-builder stack on
+  WooCommerce stores).
+- **WooCommerce:** latest stable, plus a set of the most widely-used extensions:
+  Yoast SEO, Contact Form 7, WP Mail SMTP, Site Kit by Google, Google Listings &
+  Ads, Jetpack, WooCommerce PayPal Payments, WooCommerce Stripe Gateway,
+  WooPayments, Code Snippets, Loco Translate, LiteSpeed Cache, WPForms Lite,
+  Classic Editor.
+- **Locale:** EUR currency with German formatting (`1.234,56 €`), store based in
+  Germany — exercises comma-decimal formatting and a non-ASCII currency symbol.
+- **Content:** three sample products (a simple product, a product on sale, and a
+  virtual/downloadable product), plus the standard WooCommerce pages.
+- Guest checkout enabled, pretty permalinks, onboarding wizard skipped.
+
+### Notes
+
+- **All extensions are active by default.** On a resource-constrained host the
+  admin can feel slow with this many plugins active; deactivate a few for a
+  snappier experience, e.g. `wp plugin deactivate litespeed-cache wpforms-lite
+  classic-editor`, or from **Plugins** in wp-admin. Nothing depends on all of
+  them being active.
+- **Landing page is the shop** (`/shop/`), a server-rendered page that loads
+  quickly. The WooCommerce Analytics dashboard is heavier and may take a moment.
+- Plugins are installed first and activated at the end, so the sample content is
+  created on a clean WooCommerce-only stack before the other extensions load.
+
+### Changing the WooCommerce version
+
+WooCommerce installs from the wordpress.org plugin directory, so it's always the
+**latest stable** release. To target something else, replace the WooCommerce
+step's `pluginData` with a `url` resource:
+
+- **Pin a version:** `https://downloads.wordpress.org/plugin/woocommerce.<x.y.z>.zip`
+- **Nightly / trunk:** `https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip`

--- a/blueprints/woocommerce-test-store-hello-elementor/blueprint.json
+++ b/blueprints/woocommerce-test-store-hello-elementor/blueprint.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "meta": {
+    "title": "WooCommerce Store (Hello Elementor)",
+    "description": "A WooCommerce store with a common configuration: the Hello Elementor theme with Elementor, a set of widely-used extensions, EUR / German locale, and sample products. A lifelike environment for testing against WooCommerce.",
+    "author": "alopezari",
+    "categories": [
+      "WooCommerce",
+      "Store"
+    ]
+  },
+  "landingPage": "/shop/",
+  "preferredVersions": {
+    "php": "8.3",
+    "wp": "7.0"
+  },
+  "phpExtensionBundles": [
+    "kitchen-sink"
+  ],
+  "features": {
+    "networking": true
+  },
+  "constants": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "WP_DEBUG_DISPLAY": false,
+    "WP_MEMORY_LIMIT": "512M",
+    "WP_MAX_MEMORY_LIMIT": "512M"
+  },
+  "steps": [
+    {
+      "step": "login",
+      "username": "admin",
+      "password": "password"
+    },
+    {
+      "step": "installTheme",
+      "themeData": {
+        "resource": "wordpress.org/themes",
+        "slug": "hello-elementor"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce"
+      },
+      "options": {
+        "activate": true
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "elementor"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wordpress-seo"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "contact-form-7"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wp-mail-smtp"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "google-site-kit"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "google-listings-and-ads"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "jetpack"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-paypal-payments"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-gateway-stripe"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "code-snippets"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "loco-translate"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "litespeed-cache"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "woocommerce-payments"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "wpforms-lite"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "wordpress.org/plugins",
+        "slug": "classic-editor"
+      },
+      "options": {
+        "activate": false
+      }
+    },
+    {
+      "step": "setSiteOptions",
+      "options": {
+        "permalink_structure": "/%postname%/",
+        "blogname": "Test Store",
+        "woocommerce_currency": "EUR",
+        "woocommerce_currency_pos": "right_space",
+        "woocommerce_price_thousand_sep": ".",
+        "woocommerce_price_decimal_sep": ",",
+        "woocommerce_price_num_decimals": "2",
+        "woocommerce_default_country": "DE:BE",
+        "woocommerce_store_address": "Torstrasse 1",
+        "woocommerce_store_city": "Berlin",
+        "woocommerce_store_postcode": "10119",
+        "woocommerce_enable_guest_checkout": "yes",
+        "woocommerce_api_enabled": "yes",
+        "woocommerce_calc_taxes": "no",
+        "woocommerce_enable_coupons": "yes",
+        "woocommerce_weight_unit": "kg",
+        "woocommerce_dimension_unit": "cm",
+        "woocommerce_onboarding_profile": {
+          "skipped": true
+        },
+        "woocommerce_task_list_hidden": "yes",
+        "woocommerce_task_list_welcome_modal_dismissed": "yes"
+      }
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; wp_set_current_user(1); if ( ! function_exists('wp_insert_post') ) { exit(11); } if ( ! class_exists('WC_Product_Simple') ) { exit(12); } if ( class_exists('WC_Install') ) { WC_Install::create_pages(); } $mk = function($n,$p,$s,$o=[]){ $x=new WC_Product_Simple(); $x->set_name($n); $x->set_regular_price($p); $x->set_sku($s); $x->set_status('publish'); foreach($o as $k=>$v){$m=\"set_$k\"; if(method_exists($x,$m)){$x->$m($v);}} $x->save(); }; $mk('Cotton T-Shirt','24.99','TSHIRT-01',['manage_stock'=>true,'stock_quantity'=>50]); $mk('Ceramic Mug','12.50','MUG-01',['sale_price'=>'9.99','manage_stock'=>true,'stock_quantity'=>200]); $mk('Digital Guide (PDF)','7.00','GUIDE-01',['virtual'=>true,'downloadable'=>true]);"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; $n = count( get_posts(['post_type'=>'product','post_status'=>'publish','numberposts'=>-1]) ); $shop = get_option('woocommerce_shop_page_id'); if ( $n !== 3 ) { exit(21); } if ( ! $shop ) { exit(22); } echo \"VERIFIED products=$n shop_page=$shop\";"
+    },
+    {
+      "step": "runPHP",
+      "code": "<?php ini_set('memory_limit','512M'); require_once '/wordpress/wp-load.php'; require_once ABSPATH.'wp-admin/includes/plugin.php'; wp_set_current_user(1); $want=['elementor', 'wordpress-seo', 'contact-form-7', 'wp-mail-smtp', 'google-site-kit', 'google-listings-and-ads', 'jetpack', 'woocommerce-paypal-payments', 'woocommerce-gateway-stripe', 'code-snippets', 'loco-translate', 'woocommerce-payments', 'litespeed-cache', 'wpforms-lite', 'classic-editor']; foreach (get_plugins() as $file=>$d){ $folder = (strpos($file,'/')!==false)?dirname($file):$file; if (in_array($folder,$want,true)){ activate_plugin($file); } } $active = array_filter(array_map(function($f){return (strpos($f,'/')!==false)?dirname($f):$f;}, (array)get_option('active_plugins'))); $missing = array_diff($want,$active); if (!empty($missing)){ echo 'MISSING '.implode(',',$missing); exit(31); } echo 'ACTIVATED '.count($want).' non-woo (active_total='.count((array)get_option('active_plugins')).')';"
+    }
+  ]
+}


### PR DESCRIPTION
Two blueprints that set up a WooCommerce store with a realistic configuration, so you can test plugins, themes, or WooCommerce itself against something closer to a real store than a bare install.

- `woocommerce-test-store-hello-elementor` — Hello Elementor theme, EUR / German locale
- `woocommerce-test-store-astra` — Astra theme, USD / US locale

Each installs WooCommerce (latest) plus a set of widely-used extensions (Yoast, Jetpack, Elementor, PayPal / Stripe / WooPayments, Site Kit, Google Listings & Ads, Contact Form 7, WP Mail SMTP, LiteSpeed, Loco Translate, Code Snippets, WPForms, Classic Editor), sets a realistic locale and store config, and seeds three sample products. Each folder has a README.

I split it into two because no single theme or locale dominates real stores. I took the two most common theme families and paired them with the EUR and USD profiles. The two blueprints differ only by theme and locale; everything else is identical.

## Notes

Plugins are installed inactive and activated in a final step, so the sample content is created on a WooCommerce-only stack. If everything is active up front, Elementor throws "Access denied" when the seeding step saves a page. Activating last avoids it.

All extensions are active by default. That's a lot of plugins for Playground, so the admin can feel slow on a constrained host — each README notes which ones to deactivate for a snappier site.

## Testing

- Both boot clean on WooCommerce latest via `@wp-playground/cli run-blueprint`; verified the products, pages, and locale on the running site.
- Both pass `npm run validate:pr-blueprints`.

No screenshots yet — the gallery auto-generates them on merge. Happy to add my own if you'd rather.