### PR TITLE
Fix postprocess CI: install npm deps before rebuilding apps.json

### DIFF
--- a/.github/workflows/postprocess.yml
+++ b/.github/workflows/postprocess.yml
@@ -20,6 +20,8 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20
+            - name: Install dependencies
+              run: npm ci
             - name: Install Prettier
               run: npm install -g prettier
             - name: Run reindex_postprocess.py


### PR DESCRIPTION
## Summary
- The `postprocess.yml` "build" job's "Rebuild apps.json" step runs `node scripts/build-apps-json.js`, which imports `scripts/lib/json-validation.js`, which requires the `ajv`/`ajv-formats` devDependencies.
- The job never ran `npm install`/`npm ci`, so `node_modules` was never present, causing `ERR_MODULE_NOT_FOUND` and failing the job (e.g. [run 32228164348](https://github.com/WordPress/blueprints/actions/runs/32228164348/job/95992127171#step:7:25)).
- Added an `npm ci` step after `actions/setup-node@v4`, matching the pattern already used in `has-valid-blueprint-json.yml`.

## Test plan
- [x] Ran `npm ci` locally — succeeds, lockfile is in sync.
- [x] Ran `node scripts/build-apps-json.js` locally after `npm ci` — completes successfully.