### PR TITLE
Add My WordPress recipe: Make this a hosted WordPress

### DIFF
--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -84,6 +84,23 @@ Use a `note` step for instructions or admin screens:
 }
 ```
 
+Add an `action` to a step when the app can perform it for the reader instead of
+describing where to click. Actions only run inside WordPress Playground, so the
+`description` must still make sense on its own for anyone reading elsewhere:
+
+```json
+{
+	"type": "note",
+	"title": "Download a full backup of this site",
+	"description": "Start the download right here. The same download is always available from the Site Tools icon in the bottom-left corner.",
+	"action": "backup-site"
+}
+```
+
+The only action today is `backup-site`, which asks Playground to zip the whole
+site — files and database — and hand the ZIP to the browser's downloader. An
+optional `action_label` overrides the button label.
+
 Use a `plugin` step for an entry from [blueprints/my-wordpress/plugins.json](https://github.com/WordPress/blueprints/blob/trunk/blueprints/my-wordpress/plugins.json):
 
 ```json

--- a/blueprints/my-wordpress/contributing-recipes.md
+++ b/blueprints/my-wordpress/contributing-recipes.md
@@ -28,6 +28,7 @@ Each top-level key in [recipes.json](https://github.com/WordPress/blueprints/blo
 - `gradient`: CSS gradient used by the recipe card.
 - `learn_more`: optional URL for deeper background.
 - `alternatives`: optional two-column app comparison rows for guides that map familiar external apps to installable My WordPress apps.
+- `context`: optional environment the whole recipe is limited to. Recipes without it show everywhere.
 - `steps`: ordered list of actions.
 
 Example:
@@ -48,7 +49,15 @@ Example:
 
 ## Step Types
 
-Every step should have a `type`, `title`, and `description`. Use `optional: true` for useful additions that are not required for the core workflow. Use `context` when a step only applies in a specific environment, such as `self-hosted`.
+Every step should have a `type`, `title`, and `description`. Use `optional: true` for useful additions that are not required for the core workflow. Use `context` when a step only applies in a specific environment.
+
+`context` is accepted on a step and on a whole recipe, and takes one of:
+
+- `self-hosted`: a regular WordPress install, not Playground.
+- `playground`: any WordPress Playground instance, including my.wordpress.net.
+- `my-wordpress-net`: only the persistent Playground at my.wordpress.net, for guides about that site itself, such as moving it to hosting.
+
+A recipe with a `context` is hidden entirely — from the guide grid, search and its detail page — where the context does not apply. A step with a `context` is skipped inside an otherwise visible recipe.
 
 Use `alternatives` when the recipe is mostly a discovery table rather than a linear setup flow. Each row groups familiar app names on the left and points to one app registered in [apps.json](https://github.com/WordPress/blueprints/blob/trunk/apps.json):
 

--- a/blueprints/my-wordpress/plugins.json
+++ b/blueprints/my-wordpress/plugins.json
@@ -111,12 +111,12 @@
 		"categories": ["Productivity"],
 		"landing_page": "/my-apps/"
 	},
-	"desktop-mode": {
-		"url": "https://github.com/WordPress/desktop-mode/releases/latest/download/desktop-mode.zip",
-		"title": "Desktop Mode",
+	"openstation": {
+		"url": "https://github.com/WordPress/openstation/releases/latest/download/openstation.zip",
+		"title": "Open Station",
 		"author": "WordPress",
 		"note": "Reimagines /wp-admin as a desktop OS — admin screens open as draggable, resizable windows on a wallpaper, with a dock built from the admin menu. Per-user opt-in, fully reverts on deactivation.",
 		"categories": ["Productivity"],
-		"landing_page": "/desktop-mode/"
+		"landing_page": "/wp-admin/"
 	}
 }

--- a/blueprints/my-wordpress/plugins.json
+++ b/blueprints/my-wordpress/plugins.json
@@ -118,5 +118,10 @@
 		"note": "Reimagines /wp-admin as a desktop OS — admin screens open as draggable, resizable windows on a wallpaper, with a dock built from the admin menu. Per-user opt-in, fully reverts on deactivation.",
 		"categories": ["Productivity"],
 		"landing_page": "/desktop-mode/"
+	},
+	"export-media-library": {
+		"note": "Download your entire Media Library as one ZIP — handy for backups or for taking your images along when you move to another WordPress.",
+		"categories": ["Utility"],
+		"landing_page": "/wp-admin/upload.php?page=mass-edge-export-media-library"
 	}
 }

--- a/blueprints/my-wordpress/plugins.json
+++ b/blueprints/my-wordpress/plugins.json
@@ -118,10 +118,5 @@
 		"note": "Reimagines /wp-admin as a desktop OS — admin screens open as draggable, resizable windows on a wallpaper, with a dock built from the admin menu. Per-user opt-in, fully reverts on deactivation.",
 		"categories": ["Productivity"],
 		"landing_page": "/desktop-mode/"
-	},
-	"export-media-library": {
-		"note": "Download your entire Media Library as one ZIP — handy for backups or for taking your images along when you move to another WordPress.",
-		"categories": ["Utility"],
-		"landing_page": "/wp-admin/upload.php?page=mass-edge-export-media-library"
 	}
 }

--- a/blueprints/my-wordpress/recipes.json
+++ b/blueprints/my-wordpress/recipes.json
@@ -440,60 +440,40 @@
 	"move-to-hosting": {
 		"title": "Move to WordPress Hosting",
 		"tagline": "Take what you built here anywhere",
-		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, export everything and move it to any WordPress host. Nothing you built here is lost: the same posts, pages, media and plugins run on hosted WordPress.",
+		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, download a full backup and restore it on a WordPress host. Because this site is built on WordPress Playground, the backup is the whole site: database, media, plugins, themes and settings, not just an export of your posts.",
 		"icon": "🚀",
 		"gradient": "linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%)",
 		"context": "my-wordpress-net",
 		"steps": [
 			{
 				"type": "note",
-				"title": "Pick a WordPress host",
-				"description": "Any host that runs WordPress works — a managed WordPress host, a general web host with a one-click WordPress installer, or a server you run yourself. WordPress.org keeps a list of recommended hosts. Set up a fresh, empty WordPress there before you export anything, so you have somewhere to import into.",
-				"url": "https://wordpress.org/hosting/",
-				"url_label": "See recommended hosts"
+				"title": "Download a backup from Site Tools",
+				"description": "Click the Site Tools icon in the bottom-left corner of my.wordpress.net and download a backup. This is a Playground site ZIP containing every file and the database, so nothing needs to be re-exported or reinstalled on the other side. Keep the file somewhere safe — it is also the right thing to do before trying anything risky here."
 			},
 			{
 				"type": "note",
-				"title": "Export your content",
-				"description": "Tools → Export creates a WordPress export file (WXR) with all posts, pages, comments, categories and tags. Choose \"All content\" and download the file. This is the format every WordPress can import, so it is the safest way to carry your writing across.",
-				"url": "/wp-admin/export.php",
-				"url_label": "Open Export"
-			},
-			{
-				"type": "plugin",
-				"slug": "export-media-library",
-				"title": "Download your media",
-				"description": "This site exists only in your browser, so the new host's importer cannot fetch your images from it. Export Media Library packs your whole Media Library into one ZIP you can download. Keep it next to the export file — you upload both on the new site."
-			},
-			{
-				"type": "note",
-				"title": "Import on the new host",
-				"description": "On the new site, go to Tools → Import, install the WordPress importer and upload the export file, assigning the posts to your user there. Then upload the media ZIP's files through its Media Library. Image links in posts still point at this site's address; the new site's Tools → Import screen lists search-and-replace plugins, or fix the handful of posts by hand.",
-				"url": "https://wordpress.org/documentation/article/importing-content/",
-				"url_label": "Read the import guide"
-			},
-			{
-				"type": "note",
-				"title": "Reinstall your plugins and theme",
-				"description": "Plugins and themes aren't part of the export. Note what is active under Plugins and Appearance → Themes, then install the same ones on the new host from the WordPress.org directory. Apps you added from the App Store are ordinary plugins and install the same way.",
-				"url": "/wp-admin/plugins.php",
-				"url_label": "Open Plugins"
-			},
-			{
-				"type": "github",
-				"repo": "akirk/static-archive",
-				"title": "Keep a static copy as a safety net",
-				"description": "Static Archive writes an HTML copy of every post into your uploads folder. Generate it before you move, and you have a browsable, self-contained backup of this site even if something goes wrong during the import.",
-				"optional": true
+				"title": "Restore it on a host that accepts site backups",
+				"description": "WordPress.com imports Playground ZIP files directly: start a new site through its migration flow, upload the backup, and it restores content, media, plugins and themes (a full-site import needs a paid plan; content-only import works on free sites). Other hosts often have a similar \"migrate\" or \"restore from backup\" option in their control panel.",
+				"url": "https://wordpress.com/setup/migration-signup",
+				"url_label": "Migrate to WordPress.com"
 			},
 			{
 				"type": "note",
 				"title": "Check the new site, then let this one go",
-				"description": "Open a few posts on the new host, confirm images load and links point to the new address (Settings → General shows the site URL). Once everything is there, the new site is the one to keep updating — this browser copy won't sync with it.",
+				"description": "Open a few posts on the new host, confirm images load and that Settings → General shows the new address. Once everything is there, the hosted site is the one to keep updating — this browser copy won't sync with it.",
 				"url": "/wp-admin/options-general.php",
 				"url_label": "Open Settings"
+			},
+			{
+				"type": "note",
+				"title": "Prefer a content-only move?",
+				"description": "If your host can't take a full site backup, Tools → Export still gives you a WordPress export file (WXR) with all posts and pages that any WordPress can import. Media and plugins then need to be carried over separately, so use the backup route whenever you can.",
+				"url": "/wp-admin/export.php",
+				"url_label": "Open Export",
+				"optional": true
 			}
-		]
+		],
+		"learn_more": "https://wordpress.com/support/import/#import-from-wordpress-playground"
 	},
 	"stay-in-touch": {
 		"title": "Stay in Touch",

--- a/blueprints/my-wordpress/recipes.json
+++ b/blueprints/my-wordpress/recipes.json
@@ -440,7 +440,7 @@
 	"move-to-hosting": {
 		"title": "Make this a hosted WordPress",
 		"tagline": "Take what you built here anywhere",
-		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, download a full backup and restore it on a WordPress host. Because this site is built on WordPress Playground, the backup is the whole site: database, media, plugins, themes and settings, not just an export of your posts.",
+		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, download a full backup and restore it on a WordPress host. Because this site is built on WordPress Playground, the backup is the whole site: database, media, plugins, themes and settings, not just an export of your posts. Along the way you'll pick the web address your site will live at.",
 		"icon": "🚀",
 		"gradient": "linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%)",
 		"context": "my-wordpress-net",
@@ -456,6 +456,11 @@
 				"description": "WordPress.com imports Playground ZIP files directly: start a new site through its migration flow, upload the backup, and it restores content, media, plugins and themes (a full-site import needs a paid plan; content-only import works on free sites). Other hosts often have a similar \"migrate\" or \"restore from backup\" option in their control panel.",
 				"url": "https://wordpress.com/setup/migration-signup",
 				"url_label": "Migrate to WordPress.com"
+			},
+			{
+				"type": "note",
+				"title": "Decide on a web address",
+				"description": "Here your site only has the address in this browser; a hosted site needs one everyone can use. The host offers a free address on its own domain (like yoursite.wordpress.com) that works immediately, or you can register a domain of your own (like yourname.com) — usually the choice you keep for years, so it is worth a moment's thought. Pick a name that fits what the site is about, and be aware that a custom domain costs a small yearly fee and can be changed later; links people already saved will need updating if you do."
 			},
 			{
 				"type": "note",

--- a/blueprints/my-wordpress/recipes.json
+++ b/blueprints/my-wordpress/recipes.json
@@ -438,7 +438,7 @@
 		]
 	},
 	"move-to-hosting": {
-		"title": "Move to WordPress Hosting",
+		"title": "Make this a hosted WordPress",
 		"tagline": "Take what you built here anywhere",
 		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, download a full backup and restore it on a WordPress host. Because this site is built on WordPress Playground, the backup is the whole site: database, media, plugins, themes and settings, not just an export of your posts.",
 		"icon": "🚀",

--- a/blueprints/my-wordpress/recipes.json
+++ b/blueprints/my-wordpress/recipes.json
@@ -447,8 +447,9 @@
 		"steps": [
 			{
 				"type": "note",
-				"title": "Download a backup from Site Tools",
-				"description": "Click the Site Tools icon in the bottom-left corner of my.wordpress.net and download a backup. This is a Playground site ZIP containing every file and the database, so nothing needs to be re-exported or reinstalled on the other side. Keep the file somewhere safe — it is also the right thing to do before trying anything risky here."
+				"title": "Download a full backup of this site",
+				"description": "Start the download right here. The backup is a Playground site ZIP containing every file and the database, so nothing needs to be re-exported or reinstalled on the other side. Building it takes a moment on a large site, and the file then lands in your browser's downloads. Keep it somewhere safe — it is also the right thing to do before trying anything risky here. The same download is always available from the Site Tools icon in the bottom-left corner.",
+				"action": "backup-site"
 			},
 			{
 				"type": "note",

--- a/blueprints/my-wordpress/recipes.json
+++ b/blueprints/my-wordpress/recipes.json
@@ -437,6 +437,64 @@
 			}
 		]
 	},
+	"move-to-hosting": {
+		"title": "Move to WordPress Hosting",
+		"tagline": "Take what you built here anywhere",
+		"description": "Your my.wordpress.net site lives in this browser's storage — private, but bound to one device. When you want to reach it from your phone, share it publicly, or invite others, export everything and move it to any WordPress host. Nothing you built here is lost: the same posts, pages, media and plugins run on hosted WordPress.",
+		"icon": "🚀",
+		"gradient": "linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%)",
+		"context": "my-wordpress-net",
+		"steps": [
+			{
+				"type": "note",
+				"title": "Pick a WordPress host",
+				"description": "Any host that runs WordPress works — a managed WordPress host, a general web host with a one-click WordPress installer, or a server you run yourself. WordPress.org keeps a list of recommended hosts. Set up a fresh, empty WordPress there before you export anything, so you have somewhere to import into.",
+				"url": "https://wordpress.org/hosting/",
+				"url_label": "See recommended hosts"
+			},
+			{
+				"type": "note",
+				"title": "Export your content",
+				"description": "Tools → Export creates a WordPress export file (WXR) with all posts, pages, comments, categories and tags. Choose \"All content\" and download the file. This is the format every WordPress can import, so it is the safest way to carry your writing across.",
+				"url": "/wp-admin/export.php",
+				"url_label": "Open Export"
+			},
+			{
+				"type": "plugin",
+				"slug": "export-media-library",
+				"title": "Download your media",
+				"description": "This site exists only in your browser, so the new host's importer cannot fetch your images from it. Export Media Library packs your whole Media Library into one ZIP you can download. Keep it next to the export file — you upload both on the new site."
+			},
+			{
+				"type": "note",
+				"title": "Import on the new host",
+				"description": "On the new site, go to Tools → Import, install the WordPress importer and upload the export file, assigning the posts to your user there. Then upload the media ZIP's files through its Media Library. Image links in posts still point at this site's address; the new site's Tools → Import screen lists search-and-replace plugins, or fix the handful of posts by hand.",
+				"url": "https://wordpress.org/documentation/article/importing-content/",
+				"url_label": "Read the import guide"
+			},
+			{
+				"type": "note",
+				"title": "Reinstall your plugins and theme",
+				"description": "Plugins and themes aren't part of the export. Note what is active under Plugins and Appearance → Themes, then install the same ones on the new host from the WordPress.org directory. Apps you added from the App Store are ordinary plugins and install the same way.",
+				"url": "/wp-admin/plugins.php",
+				"url_label": "Open Plugins"
+			},
+			{
+				"type": "github",
+				"repo": "akirk/static-archive",
+				"title": "Keep a static copy as a safety net",
+				"description": "Static Archive writes an HTML copy of every post into your uploads folder. Generate it before you move, and you have a browsable, self-contained backup of this site even if something goes wrong during the import.",
+				"optional": true
+			},
+			{
+				"type": "note",
+				"title": "Check the new site, then let this one go",
+				"description": "Open a few posts on the new host, confirm images load and links point to the new address (Settings → General shows the site URL). Once everything is there, the new site is the one to keep updating — this browser copy won't sync with it.",
+				"url": "/wp-admin/options-general.php",
+				"url_label": "Open Settings"
+			}
+		]
+	},
 	"stay-in-touch": {
 		"title": "Stay in Touch",
 		"tagline": "A private contact directory with reminders",


### PR DESCRIPTION
## Summary
- New recipe `move-to-hosting` ("Make this a hosted WordPress") in `blueprints/my-wordpress/recipes.json`. Since a my.wordpress.net site is a Playground, the guide is built around the Site Tools backup (bottom-left icon), which is a full Playground ZIP with files and database. It points at the WordPress.com migration flow, which imports Playground ZIP files directly (full-site import on a paid plan, content-only on free sites, per the [WordPress.com import guide](https://wordpress.com/support/import/#import-from-wordpress-playground)), and keeps Tools → Export as an optional content-only fallback.
- The recipe carries `"context": "my-wordpress-net"`, a new recipe-level field, so self-hosted sites and generic Playgrounds don't see a guide about leaving a site they are not on.
- `contributing-recipes.md` documents `context` on recipes and steps and the three values (`self-hosted`, `playground`, `my-wordpress-net`).

<img width="1752" height="2153" alt="Screenshot 2026-08-25 at 17 20 04" src="https://github.com/user-attachments/assets/f5de046d-d127-418f-a7dc-53ed43eb309f" />

## Verification
- `npm run validate:my-wordpress-json` passes with `MY_APPS_SCHEMA_BASE_URL` pointed at the schema from that branch (all 9 checks valid).
- Formatted with the repository Prettier settings.
- Not verified in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance for moving a browser-based WordPress Playground site to hosted WordPress.
  - Covers full backups, restoration, domain selection, verification, and an optional content-only export.
  - Replaced the Desktop Mode plugin listing with the OpenStation plugin.

- **Documentation**
  - Added support for documenting recipe and step availability across self-hosted, Playground, and hosted WordPress contexts.
  - Clarified how context-specific recipes and steps are displayed.
  - Documented Playground-only actions, including site backups and customizable action labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->