### PR TITLE
Also generate mobile screenshots for Blueprints

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -64,7 +64,7 @@ jobs:
             - name: Check for changes
               id: check_changes
               run: |
-                  git add blueprints/*/screenshot.jpg
+                  git add blueprints/*/screenshot.jpg blueprints/*/screenshot-mobile.jpg
                   if [ -n "$(git status --porcelain)" ]; then
                     echo "has_changes=true" >> $GITHUB_OUTPUT
                   else
@@ -76,7 +76,7 @@ jobs:
               run: |
                   git config --global user.name "github-actions[bot]"
                   git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                  git add blueprints/*/screenshot.jpg
+                  git add blueprints/*/screenshot.jpg blueprints/*/screenshot-mobile.jpg
                   git commit -m "chore: add missing Blueprint screenshots"
                   git push
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ To help your Blueprint stand out in the gallery, include a screenshot alongside 
 -   Add a JPEG named `screenshot.jpg` inside your Blueprint directory (for example, `blueprints/my-blueprint/screenshot.jpg`). JPEG keeps file sizes small and matches the automation that builds the site.
 -   Shoot in a landscape aspect ratio (≈16:9) at about 1600–2000px wide so the preview stays sharp on Retina displays, and try to keep it under ~500 KB.
 -   If you don't provide a screenshot, a CI job will generate one for you automatically. A blank install often makes for a poor screenshot; if your Blueprint directory also contains a `demo.json` — a Blueprint that installs the app and seeds it with sample content — the CI job runs that instead of `blueprint.json` so the screenshot shows the app in use.
+-   The same CI job also takes a phone-width screenshot (390px wide, 2× scale) and saves it as `screenshot-mobile.jpg`. It's published in `index.json` as `screenshot_mobile_url`. To supply your own, add a JPEG with that name next to `blueprint.json`.
 
 ## Need help?
 

--- a/reindex_postprocess.py
+++ b/reindex_postprocess.py
@@ -112,6 +112,9 @@ def build_json_index():
                         else:
                             screenshot_url = build_raw_repo_url(screenshot_path)
                         meta_with_media['screenshot_url'] = screenshot_url
+                    mobile_path = os.path.join(os.path.dirname(path), 'screenshot-mobile.jpg').replace('\\', '/')
+                    if os.path.exists(mobile_path):
+                        meta_with_media['screenshot_mobile_url'] = build_raw_repo_url(mobile_path)
                     # Add featured flag based on whether the title is in highlighted_blueprints
                     meta_with_media['featured'] = meta.get('title', '') in highlighted_blueprints
                     index[path] = meta_with_media

--- a/scripts/screenshot-blueprints.ts
+++ b/scripts/screenshot-blueprints.ts
@@ -346,11 +346,21 @@ async function main() {
   // Filter: those without a screenshot for the variant yet, plus any this PR
   // touched the blueprint.json/demo.json of (their existing screenshot may be stale).
   const forceRegenSlugs = getForceRegenSlugs();
+  // On a pull request, only shoot the Blueprints that PR is about: those it
+  // touched, and those still missing a desktop screenshot. Backfilling every
+  // Blueprint that lacks a newer variant (e.g. mobile) would turn each PR into
+  // a full catalogue run; that happens on workflow_dispatch instead.
+  const isPullRequest = (process.env.GITHUB_EVENT_NAME ?? '').startsWith('pull_request');
+  const desktop = VARIANTS[0];
   const toShoot = new Map<Variant, string[]>();
   for (const variant of VARIANTS) {
     const list: string[] = [];
     for (const slug of slugs) {
-      if (!(await hasScreenshot(slug, variant)) || forceRegenSlugs.has(slug)) {
+      const missing = !(await hasScreenshot(slug, variant));
+      const inScope =
+        forceRegenSlugs.has(slug) ||
+        (variant === desktop ? missing : !(await hasScreenshot(slug, desktop)));
+      if (isPullRequest ? inScope : missing || forceRegenSlugs.has(slug)) {
         list.push(slug);
       }
     }

--- a/scripts/screenshot-blueprints.ts
+++ b/scripts/screenshot-blueprints.ts
@@ -372,6 +372,7 @@ async function main() {
   }
 
   const browser = await chromium.launch({ headless: true });
+  const failures: string[] = [];
 
   // Device emulation (isMobile, touch) is fixed per context, so each variant
   // gets its own context and its own Playground boot per Blueprint.
@@ -379,12 +380,25 @@ async function main() {
     console.log(`Shooting ${list.length} ${variant.name} screenshot(s)`);
     const context = await browser.newContext(variant.context);
     for (const slug of list) {
-      await shootBlueprint(context, slug, variant);
+      // One Blueprint failing (Playground slow, a step timing out) must not
+      // abort the run: that would throw away every screenshot already taken
+      // and the next run would start from scratch. Log it and move on; the
+      // file stays missing, so the next run retries just that one.
+      try {
+        await shootBlueprint(context, slug, variant);
+      } catch (e) {
+        failures.push(`${slug} (${variant.name})`);
+        console.log(`::warning::Failed to shoot ${slug} (${variant.name}): ${(e as Error).message}`);
+      }
     }
     await context.close();
   }
 
   await browser.close();
+
+  if (failures.length > 0) {
+    console.log(`::warning::${failures.length} screenshot(s) failed and will be retried next run: ${failures.join(', ')}`);
+  }
 }
 
 main().catch((e) => {

--- a/scripts/screenshot-blueprints.ts
+++ b/scripts/screenshot-blueprints.ts
@@ -48,6 +48,44 @@ const RAW_REPO =
 const RAW_REF =
   process.env.BLUEPRINTS_RAW_REF || pullRequestBlueprintSource?.ref || REF;
 
+// Each Blueprint is shot once per variant. The desktop shot is the classic
+// gallery image; the mobile shot shows the same Blueprint at phone width.
+type Variant = {
+  name: string;
+  filename: string;
+  context: Parameters<import('playwright').Browser['newContext']>[0];
+  // The desktop shot is zoomed so a 1920px page reads as a thumbnail; at phone
+  // width that would crop the layout, so mobile is shot at 1:1.
+  zoom: string | null;
+  // Where to park the mouse so it doesn't hover the admin-bar logo at (0,0).
+  mouseRest: { x: number; y: number };
+};
+
+const VARIANTS: Variant[] = [
+  {
+    name: 'desktop',
+    filename: 'screenshot.jpg',
+    context: {
+      ...devices['Desktop Chrome'],
+      deviceScaleFactor: 1,
+      viewport: { width: 1920, height: 1080 },
+    },
+    zoom: '150%',
+    mouseRest: { x: 1900, y: 1070 },
+  },
+  {
+    name: 'mobile',
+    filename: 'screenshot-mobile.jpg',
+    context: {
+      ...devices['iPhone 13'],
+      deviceScaleFactor: 2,
+      viewport: { width: 390, height: 844 },
+    },
+    zoom: null,
+    mouseRest: { x: 380, y: 830 },
+  },
+];
+
 async function ensureDir(p: string) {
   await fs.mkdir(p, { recursive: true });
 }
@@ -149,11 +187,14 @@ async function fileExists(p: string | null): Promise<boolean> {
   }
 }
 
-async function hasScreenshot(slug: string): Promise<boolean> {
+async function hasScreenshot(slug: string, variant: Variant): Promise<boolean> {
   // Default gallery behavior: if meta.screenshot isn't set, it expects `screenshot.jpg`
-  // next to `blueprint.json`.
-  const defaultScreenshot = path.join(BLUEPRINTS_DIR, slug, 'screenshot.jpg');
+  // next to `blueprint.json`; the mobile variant likewise expects `screenshot-mobile.jpg`.
+  const defaultScreenshot = path.join(BLUEPRINTS_DIR, slug, variant.filename);
   if (await fileExists(defaultScreenshot)) return true;
+
+  // meta.screenshot only overrides the desktop image.
+  if (variant.name !== 'desktop') return false;
 
   const bp = await readBlueprint(slug);
   const scr = bp?.meta?.screenshot;
@@ -174,39 +215,19 @@ async function readTitle(slug: string) {
   return bp?.meta?.title ?? slug;
 }
 
-async function main() {
-  const slugs = await listBlueprintSlugs();
-  console.log(`Using Blueprint source: ${RAW_REPO}@${RAW_REF}`);
-
-  // Filter: those without any screenshot yet, plus any this PR touched the
-  // blueprint.json/demo.json of (their existing screenshot may be stale).
-  const forceRegenSlugs = getForceRegenSlugs();
-  const toShoot: string[] = [];
-  for (const slug of slugs) {
-    if (!(await hasScreenshot(slug)) || forceRegenSlugs.has(slug)) {
-      toShoot.push(slug);
-    }
-  }
-  if (toShoot.length === 0) {
-    console.log('All Blueprints already have screenshots. Nothing to do.');
-    return;
-  }
-
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({
-    ...devices['Desktop Chrome'],
-    deviceScaleFactor: 1,
-    viewport: { width: 1920, height: 1080 },
-  });
-
-  for (const slug of toShoot) {
-    const page = await context.newPage();
+async function shootBlueprint(
+  context: import('playwright').BrowserContext,
+  slug: string,
+  variant: Variant
+) {
+  const page = await context.newPage();
+  try {
     // Prefer demo.json when present: it's a blueprint that also seeds sample
     // content, so the screenshot shows the app in use rather than freshly installed.
     const useDemo = await hasDemoJson(slug);
     const sourceUrl = useDemo ? rawFileUrl(slug, 'demo.json') : rawBlueprintUrl(slug);
     if (useDemo) {
-      console.log(`Using demo.json for ${slug} screenshot`);
+      console.log(`Using demo.json for ${slug} ${variant.name} screenshot`);
     }
     const url = `https://playground.wordpress.net/?mode=seamless&blueprint-url=${encodeURIComponent(
       sourceUrl
@@ -225,8 +246,7 @@ async function main() {
     const frame = await frameElement?.contentFrame();
     if (!frame) {
       console.error(`Failed to get frame content for ${slug}`);
-      await page.close();
-      continue;
+      return;
     }
 
     // Wait for the progress bar to NOT exist (not just be hidden) - 5 minute timeout
@@ -245,11 +265,10 @@ async function main() {
     // Get the WordPress iframe's content frame
     const wpFrameElement = await wpFrame.elementHandle();
     const wpContentFrame = await wpFrameElement?.contentFrame();
-    
+
     if (!wpContentFrame) {
       console.error(`Failed to get WordPress frame content for ${slug}`);
-      await page.close();
-      continue;
+      return;
     }
 
     // Wait for WordPress content to be loaded by checking for WordPress-specific indicators
@@ -260,7 +279,7 @@ async function main() {
           // Check for canonical URL
           const canonical = document.querySelector('link[rel="canonical"]');
           if (canonical) return true;
-          
+
           // Check for wp-content in any script or link tags
           const scripts = Array.from(document.querySelectorAll('script[src], link[href]'));
           const hasWpContent = scripts.some(el => {
@@ -268,7 +287,7 @@ async function main() {
             return src && src.includes('/wp-content/');
           });
           if (hasWpContent) return true;
-          
+
           // Check if body has meaningful content
           const body = document.body;
           return body && body.children.length > 0;
@@ -283,21 +302,22 @@ async function main() {
     // Additional wait to ensure visual rendering is complete
     await page.waitForTimeout(2000);
 
-    // Set zoom to 150% on the WordPress content frame
-    try {
-      await wpContentFrame.evaluate(() => {
-        (document.body.style as any).zoom = '150%';
-      });
-      // Wait a bit for zoom to apply
-      await page.waitForTimeout(500);
-    } catch (e) {
-      console.log(`Failed to set zoom for ${slug}, continuing anyway`);
+    if (variant.zoom) {
+      try {
+        await wpContentFrame.evaluate((zoom) => {
+          (document.body.style as any).zoom = zoom;
+        }, variant.zoom);
+        // Wait a bit for zoom to apply
+        await page.waitForTimeout(500);
+      } catch (e) {
+        console.log(`Failed to set zoom for ${slug}, continuing anyway`);
+      }
     }
 
     // The mouse defaults to (0,0), which hovers the WordPress logo in the admin
     // bar and pops open its dropdown. Move it away and close any open menu.
     try {
-      await page.mouse.move(1900, 1070);
+      await page.mouse.move(variant.mouseRest.x, variant.mouseRest.y);
       await wpContentFrame.evaluate(() => {
         document
           .querySelectorAll('#wpadminbar .hover, #wpadminbar .menupop:focus-within')
@@ -310,12 +330,48 @@ async function main() {
     }
 
     // Screenshot the WordPress iframe
-    const blueprintDir = path.join(BLUEPRINTS_DIR, slug);
-    const out = path.join(blueprintDir, 'screenshot.jpg');
+    const out = path.join(BLUEPRINTS_DIR, slug, variant.filename);
     await wpFrame.screenshot({ path: out, type: 'jpeg', quality: 70 });
 
-    console.log(`Shot: ${slug} -> ${path.relative(ROOT, out)}`);
+    console.log(`Shot: ${slug} (${variant.name}) -> ${path.relative(ROOT, out)}`);
+  } finally {
     await page.close();
+  }
+}
+
+async function main() {
+  const slugs = await listBlueprintSlugs();
+  console.log(`Using Blueprint source: ${RAW_REPO}@${RAW_REF}`);
+
+  // Filter: those without a screenshot for the variant yet, plus any this PR
+  // touched the blueprint.json/demo.json of (their existing screenshot may be stale).
+  const forceRegenSlugs = getForceRegenSlugs();
+  const toShoot = new Map<Variant, string[]>();
+  for (const variant of VARIANTS) {
+    const list: string[] = [];
+    for (const slug of slugs) {
+      if (!(await hasScreenshot(slug, variant)) || forceRegenSlugs.has(slug)) {
+        list.push(slug);
+      }
+    }
+    if (list.length > 0) toShoot.set(variant, list);
+  }
+  if (toShoot.size === 0) {
+    console.log('All Blueprints already have screenshots. Nothing to do.');
+    return;
+  }
+
+  const browser = await chromium.launch({ headless: true });
+
+  // Device emulation (isMobile, touch) is fixed per context, so each variant
+  // gets its own context and its own Playground boot per Blueprint.
+  for (const [variant, list] of toShoot) {
+    console.log(`Shooting ${list.length} ${variant.name} screenshot(s)`);
+    const context = await browser.newContext(variant.context);
+    for (const slug of list) {
+      await shootBlueprint(context, slug, variant);
+    }
+    await context.close();
   }
 
   await browser.close();


### PR DESCRIPTION
The screenshot job now shoots each Blueprint twice: the existing 1920px desktop `screenshot.jpg`, and a 390px phone-width image (iPhone 13 emulation, 2× scale) saved as `screenshot-mobile.jpg`.

- `scripts/screenshot-blueprints.ts`: the per-Blueprint shoot is factored into `shootBlueprint()` and run once per variant, each with its own browser context (device emulation is fixed per context). Mobile is shot at 1:1 rather than the 150% zoom used for desktop, which would crop a phone layout.
- On a pull request, only the Blueprints the PR touched (or that still lack a desktop screenshot) are shot, for both variants. Backfilling `screenshot-mobile.jpg` for the existing catalogue happens on `workflow_dispatch`, which opens its own PR via `create-pull-request`.
- `screenshots.yml`: also `git add` the new file. Note `pull_request_target` runs the workflow file from `trunk`, so this part only takes effect after merge — which is why the first CI run on this PR shot everything and then failed to commit ("nothing added to commit but untracked files present").
- `reindex_postprocess.py`: `index.json` gains `screenshot_mobile_url` when the file exists.
- `CONTRIBUTING.md`: documents the new file.

The gallery doesn't display the mobile image yet; this PR is to see whether the shots are worth showing.

Verified locally on a scratch copy: both variants render, the mobile one is 780×1688 with the phone layout of the demo app; the PR/dispatch selection logic was exercised with `GITHUB_EVENT_NAME`/`CHANGED_FILES` set by hand.

After merge: trigger the workflow manually once to backfill mobile screenshots for all Blueprints (took ~13 minutes in the first run here).

https://claude.ai/code/session_012N59K5u54fUPFYZnVSGd4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating and publishing mobile Blueprint screenshots alongside desktop screenshots.
  - Mobile screenshot links are now included in Blueprint catalog metadata when available.
  - Screenshot updates now cover the appropriate desktop and mobile variants, including changed Blueprints.
  - Screenshot generation can continue when individual Blueprints fail, with failures reported for follow-up.

- **Documentation**
  - Added contribution guidance for providing mobile screenshots, including required file name, dimensions, and placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->