### PR TITLE
Sync the Households and Collectibles launcher icons

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -41,10 +41,7 @@
 		"description": "Catalog your collections — coins, stamps, banknotes, trading cards, records, books, comics, watches, or whatever else you keep in a drawer. Each kind of collection asks for the fields and the grading scale that kind actually uses, and every collection has photos, tags, wishlists and totals.",
 		"author": "Alex Kirk",
 		"categories": ["Apps", "Productivity"],
-		"icon": "dashicons-archive",
-		"icon_background": "linear-gradient(135deg, #5f2c82, #49a09d)",
-		"icon_color": "#fff",
-		"icon_shadow": true
+		"icon": "https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/collectibles/icon.svg"
 	},
 	"blueprints/cookbook/blueprint.json": {
 		"title": "Cookbook",
@@ -82,7 +79,7 @@
 		"author": "Alex Kirk",
 		"categories": ["Apps", "Productivity"],
 		"icon": "dashicons-admin-home",
-		"icon_background": "linear-gradient(135deg, #c31432, #240b36)",
+		"icon_background": "linear-gradient(135deg, #9b5d2f, #d29561)",
 		"icon_color": "#fff",
 		"icon_shadow": true
 	},

--- a/blueprints/collectibles/app-meta.json
+++ b/blueprints/collectibles/app-meta.json
@@ -1,6 +1,3 @@
 {
-	"icon": "dashicons-archive",
-	"icon_background": "linear-gradient(135deg, #5f2c82, #49a09d)",
-	"icon_color": "#fff",
-	"icon_shadow": true
+	"icon": "https://raw.githubusercontent.com/akirk/collectibles/main/assets/icon.svg"
 }

--- a/blueprints/collectibles/icon.svg
+++ b/blueprints/collectibles/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+	<circle cx="12" cy="12" r="10" fill="#a9762b"/>
+	<circle cx="12" cy="12" r="7.6" fill="#f7e6c8"/>
+	<path d="M12 6.5l1.72 3.7 3.98.53-2.93 2.79.74 4.04L12 15.54l-3.51 2.02.74-4.04-2.93-2.79 3.98-.53z" fill="#a9762b"/>
+</svg>

--- a/blueprints/households/app-meta.json
+++ b/blueprints/households/app-meta.json
@@ -1,6 +1,6 @@
 {
 	"icon": "dashicons-admin-home",
-	"icon_background": "linear-gradient(135deg, #c31432, #240b36)",
+	"icon_background": "linear-gradient(135deg, #9b5d2f, #d29561)",
 	"icon_color": "#fff",
 	"icon_shadow": true
 }


### PR DESCRIPTION
Both app-meta.json entries described an icon their plugin does not use, so
the catalog showed something different from the app's own launcher.

**Households** registers `dashicons-admin-home` on a terracotta tile
(`#9b5d2f → #d29561`) in its `App` registration, and that is what its
launcher renders. `app-meta.json` carried `#c31432 → #240b36`, which appears
nowhere in the plugin and ended at a near-black stop, making it the darkest
tile in the catalog.

**Collectibles** registers its own SVG as the launcher icon and declares no
tile background at all. `app-meta.json` named `dashicons-archive` — which is
in the plugin, but as the `menu_icon` for its Collection post type, i.e. the
admin-menu icon — plus a purple-to-teal gradient invented to go with it.

This takes both from the plugins and vendors the Collectibles icon the way
the other upstream icons here are vendored:

- `npm run sync:app-icons` wrote `blueprints/collectibles/icon.svg`, byte
  identical to the plugin's `assets/icon.svg`.
- `npm run build:apps-json` (then Prettier) rebuilt `apps.json`, resolving
  the Collectibles icon to the vendored copy on trunk, as the build script
  intends.

The icon URL points at the plugin repository's `main`, matching Memex,
Wordopedia and Apiary Press, which all install from `dist/main` while
naming `main` as their icon source.

Every other app already agrees with its plugin: I diffed the `app_icon*`
registrations of the local checkouts against `app-meta.json` and Cookbook,
Familypedia, Flight Log, Learn WordPress, Post Collection, Traveler and
WordCamp Companion match byte for byte, as do the URL-icon apps.

Verified by rendering: with the vendored SVG in place, the consuming
catalog resolves it to a local copy and renders an image tile, and
Households renders the terracotta tile its launcher shows.

https://claude.ai/code/session_01GBA3RqUGqfeS5ZZGawf2Wt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Collectibles app icon to use a refreshed SVG asset.
  - Changed the Households app icon background from a red-purple gradient to a brown-orange gradient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->